### PR TITLE
feat(#11 ): 일정 수정 기능 추가

### DIFF
--- a/src/main/java/beyond/momentours/plan/command/application/controller/PlanController.java
+++ b/src/main/java/beyond/momentours/plan/command/application/controller/PlanController.java
@@ -4,7 +4,9 @@ import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.plan.command.application.dto.PlanDTO;
 import beyond.momentours.plan.command.application.mapper.PlanConverter;
 import beyond.momentours.plan.command.application.service.PlanService;
+import beyond.momentours.plan.command.domain.vo.request.RequestEditPlanVO;
 import beyond.momentours.plan.command.domain.vo.request.RequestRegisterPlanVO;
+import beyond.momentours.plan.command.domain.vo.response.ResponseEditPlanVO;
 import beyond.momentours.plan.command.domain.vo.response.ResponseRegisterPlanVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,24 @@ public class PlanController {
             return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (CommonException e) {
             log.error("일정 등록 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @PatchMapping("/edit")
+    public ResponseEntity<?> editPlan(@RequestBody RequestEditPlanVO request) {
+        log.info("수정 요청된 request 데이터 : {}", request);
+        try {
+            PlanDTO planDTO = planConverter.fromEditVOToDTO(request);
+            PlanDTO editedPlan = planService.editPlan(planDTO);
+            ResponseEditPlanVO response = planConverter.fromDTOToEditVO(editedPlan);
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (CommonException e) {
+            log.error("일정 수정 오류: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         } catch (Exception e) {
             log.error("예상치 못한 오류", e);

--- a/src/main/java/beyond/momentours/plan/command/application/dto/PlanDTO.java
+++ b/src/main/java/beyond/momentours/plan/command/application/dto/PlanDTO.java
@@ -16,6 +16,7 @@ public class PlanDTO {
     private String planContent;
     private LocalDateTime planStartDate;
     private LocalDateTime planEndDate;
+    private LocalDateTime planReminderDatetime;
     private Boolean planStatus;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/beyond/momentours/plan/command/application/mapper/PlanConverter.java
+++ b/src/main/java/beyond/momentours/plan/command/application/mapper/PlanConverter.java
@@ -2,7 +2,9 @@ package beyond.momentours.plan.command.application.mapper;
 
 import beyond.momentours.plan.command.application.dto.PlanDTO;
 import beyond.momentours.plan.command.domain.aggregate.entity.Plan;
+import beyond.momentours.plan.command.domain.vo.request.RequestEditPlanVO;
 import beyond.momentours.plan.command.domain.vo.request.RequestRegisterPlanVO;
+import beyond.momentours.plan.command.domain.vo.response.ResponseEditPlanVO;
 import beyond.momentours.plan.command.domain.vo.response.ResponseRegisterPlanVO;
 import org.springframework.stereotype.Component;
 
@@ -14,7 +16,7 @@ public class PlanConverter {
                 .planContent(registerPlanVO.getPlanContent())
                 .planStartDate(registerPlanVO.getPlanStartDate())
                 .planEndDate(registerPlanVO.getPlanEndDate())
-                .memberId(registerPlanVO.getMemberId())
+                .planReminderDatetime(registerPlanVO.getPlanReminderDatetime())
                 .courseId(registerPlanVO.getCourseId())
                 .build();
     }
@@ -25,6 +27,7 @@ public class PlanConverter {
                 .planContent(savePlanDTO.getPlanContent())
                 .planStartDate(savePlanDTO.getPlanStartDate())
                 .planEndDate(savePlanDTO.getPlanEndDate())
+                .planReminderDatetime(savePlanDTO.getPlanReminderDatetime())
                 .coupleId(savePlanDTO.getCoupleId())
                 .courseId(savePlanDTO.getCourseId())
                 .build();
@@ -36,6 +39,7 @@ public class PlanConverter {
                 .planContent(planDTO.getPlanContent())
                 .planStartDate(planDTO.getPlanStartDate())
                 .planEndDate(planDTO.getPlanEndDate())
+                .planReminderDatetime(planDTO.getPlanReminderDatetime())
                 .memberId(planDTO.getMemberId())
                 .coupleId(coupleId)
                 .courseId(planDTO.getCourseId())
@@ -49,11 +53,34 @@ public class PlanConverter {
                 .planContent(plan.getPlanContent())
                 .planStartDate(plan.getPlanStartDate())
                 .planEndDate(plan.getPlanEndDate())
+                .planReminderDatetime(plan.getPlanReminderDatetime())
                 .createdAt(plan.getCreatedAt())
                 .updatedAt(plan.getUpdatedAt())
                 .memberId(plan.getMemberId())
                 .coupleId(plan.getCoupleId())
                 .courseId(plan.getCourseId())
+                .build();
+    }
+
+    public PlanDTO fromEditVOToDTO(RequestEditPlanVO editPlanVO) {
+        return PlanDTO.builder()
+                .planTitle(editPlanVO.getPlanTitle())
+                .planContent(editPlanVO.getPlanContent())
+                .planStartDate(editPlanVO.getPlanStartDate())
+                .planEndDate(editPlanVO.getPlanEndDate())
+                .planReminderDatetime(editPlanVO.getPlanReminderDatetime())
+                .courseId(editPlanVO.getCourseId())
+                .build();
+    }
+
+    public ResponseEditPlanVO fromDTOToEditVO(PlanDTO editedPlan) {
+        return ResponseEditPlanVO.builder()
+                .planTitle(editedPlan.getPlanTitle())
+                .planContent(editedPlan.getPlanContent())
+                .planStartDate(editedPlan.getPlanStartDate())
+                .planEndDate(editedPlan.getPlanEndDate())
+                .planReminderDatetime(editedPlan.getPlanReminderDatetime())
+                .updatedAt(editedPlan.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanService.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanService.java
@@ -4,4 +4,6 @@ import beyond.momentours.plan.command.application.dto.PlanDTO;
 
 public interface PlanService {
     PlanDTO registerPlan(PlanDTO planDTO);
+
+    PlanDTO editPlan(PlanDTO planDTO);
 }

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanServiceImpl.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanServiceImpl.java
@@ -1,5 +1,7 @@
 package beyond.momentours.plan.command.application.service;
 
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.common.exception.ErrorCode;
 import beyond.momentours.plan.command.application.mapper.PlanConverter;
 import beyond.momentours.plan.command.application.dto.PlanDTO;
 import beyond.momentours.plan.command.domain.aggregate.entity.Plan;
@@ -20,9 +22,11 @@ public class PlanServiceImpl implements PlanService {
 
     @Override
     public PlanDTO registerPlan(PlanDTO planDTO) {
-        Long memberId = planDAO.findByMemberId(planDTO.getMemberId());
-        Long coupleId = planDAO.findByCoupleId(memberId);
+        // 로그인 사용자 ID를 토큰에서 가져오기
+        Long memberId = getLoggedInMemberId(); // getLoggedInMemberId 는 로그인한 유저의 memberId를 토큰에서 가져온다는 가정으로 써둔 메서드
+        planDTO.setMemberId(memberId);
 
+        Long coupleId = planDAO.findByCoupleId(memberId);
         log.info("memberId : {} , coupleId : {}", memberId, coupleId);
 
         Plan plan = planConverter.fromDTOToEntity(planDTO, coupleId);
@@ -43,4 +47,39 @@ public class PlanServiceImpl implements PlanService {
 
         return result;
     }
+
+    @Override
+    public PlanDTO editPlan(PlanDTO planDTO) {
+        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
+        planDTO.setMemberId(memberId);
+
+        Plan existingPlan = planRepository.findById(planDTO.getPlanId()).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PLAN));
+        log.info("기존 Plan 데이터: {}", existingPlan);
+
+        if (!existingPlan.getMemberId().equals(memberId)) {
+            log.error("수정 권한 없음 : 요청한 사용자 ID: {}, Plan 소유자 ID: {}", memberId, existingPlan.getMemberId());
+            throw new CommonException(ErrorCode.ACCESS_DENIED);
+        }
+
+        updatePlan(planDTO, existingPlan);
+        log.info("수정 후 Plan : {}", existingPlan);
+
+        planRepository.save(existingPlan);
+
+        return planConverter.fromEntityToDTO(existingPlan);
+    }
+
+    private void updatePlan(PlanDTO planDTO, Plan existingPlan) {
+        if (planDTO.getPlanTitle() != null) existingPlan.updateTitle(planDTO.getPlanTitle());
+        if (planDTO.getPlanContent() != null) existingPlan.updateContent(planDTO.getPlanContent());
+        if (planDTO.getPlanStartDate() != null) existingPlan.updateStartDate(planDTO.getPlanStartDate());
+        if (planDTO.getPlanEndDate() != null) existingPlan.updateEndDate(planDTO.getPlanEndDate());
+        if (planDTO.getPlanReminderDatetime() != null)
+            existingPlan.updateReminderDatetime(planDTO.getPlanReminderDatetime());
+        if (planDTO.getCourseId() != null) {
+            Long courseId = planDAO.findByCourseId(planDTO.getCourseId());
+            existingPlan.updateCourseId(courseId);
+        }
+    }
+
 }

--- a/src/main/java/beyond/momentours/plan/command/domain/aggregate/entity/Plan.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/aggregate/entity/Plan.java
@@ -31,6 +31,9 @@ public class Plan {
     @Column(name = "plan_end_date", nullable = false)
     private LocalDateTime planEndDate;
 
+    @Column(name = "plan_reminder_datetime")
+    private LocalDateTime planReminderDatetime;
+
     @Column(name = "plan_status", nullable = false)
     private Boolean planStatus;
 
@@ -57,4 +60,47 @@ public class Plan {
     public void setCourseId(Plan plan, Long courseId) {
         plan.courseId = courseId;
     }
+
+    public void updateTitle(String planTitle) {
+        if (planTitle != null) {
+            this.planTitle = planTitle;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateContent(String planContent) {
+        if (planContent != null) {
+            this.planContent = planContent;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateStartDate(LocalDateTime planStartDate) {
+        if (planStartDate != null) {
+            this.planStartDate = planStartDate;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateEndDate(LocalDateTime planEndDate) {
+        if (planEndDate != null) {
+            this.planEndDate = planEndDate;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateReminderDatetime(LocalDateTime planReminderDatetime) {
+        if (planReminderDatetime != null) {
+            this.planReminderDatetime = planReminderDatetime;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateCourseId(Long courseId) {
+        if (courseId != null) {
+            this.courseId = courseId;
+            this.updatedAt = LocalDateTime.now();
+        }
+    }
+
 }

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestEditPlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestEditPlanVO.java
@@ -1,0 +1,34 @@
+package beyond.momentours.plan.command.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RequestEditPlanVO {
+    @JsonProperty("plan_id")
+    private Long planId;
+
+    @JsonProperty("plan_title")
+    private String planTitle;
+
+    @JsonProperty("plan_content")
+    private String planContent;
+
+    @JsonProperty("plan_start_date")
+    private LocalDateTime planStartDate;
+
+    @JsonProperty("plan_end_date")
+    private LocalDateTime planEndDate;
+
+    @JsonProperty("plan_reminder_datetime")
+    private LocalDateTime planReminderDatetime;
+
+    @JsonProperty("course_id")
+    private Long courseId;
+}

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestRegisterPlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestRegisterPlanVO.java
@@ -23,8 +23,8 @@ public class RequestRegisterPlanVO {
     @JsonProperty("plan_end_date")
     private LocalDateTime planEndDate;
 
-    @JsonProperty("member_id")
-    private Long memberId;
+    @JsonProperty("plan_reminder_datetime")
+    private LocalDateTime planReminderDatetime;
 
     @JsonProperty("course_id")
     private Long courseId;

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseEditPlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseEditPlanVO.java
@@ -1,0 +1,35 @@
+package beyond.momentours.plan.command.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResponseEditPlanVO {
+    @JsonProperty("plan_id")
+    private Long planId;
+
+    @JsonProperty("plan_title")
+    private String planTitle;
+
+    @JsonProperty("plan_content")
+    private String planContent;
+
+    @JsonProperty("plan_start_date")
+    private LocalDateTime planStartDate;
+
+    @JsonProperty("plan_end_date")
+    private LocalDateTime planEndDate;
+
+    @JsonProperty("plan_reminder_datetime")
+    private LocalDateTime planReminderDatetime;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseRegisterPlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseRegisterPlanVO.java
@@ -24,6 +24,9 @@ public class ResponseRegisterPlanVO {
     @JsonProperty("plan_end_date")
     private LocalDateTime planEndDate;
 
+    @JsonProperty("plan_reminder_datetime")
+    private LocalDateTime planReminderDatetime;
+
     @JsonProperty("created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/beyond/momentours/plan/query/repository/PlanMapper.java
+++ b/src/main/java/beyond/momentours/plan/query/repository/PlanMapper.java
@@ -5,8 +5,6 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface PlanMapper {
 
-    Long findByMemberId(Long memberId);
-
     Long findByCoupleId(Long memberId);
 
     Long findByCourseId(Long courseId);

--- a/src/main/resources/beyond/momentours/mapper/PlanMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/PlanMapper.xml
@@ -18,13 +18,6 @@
         <result property="courseId" column="course_id"/>
     </resultMap>
 
-    <select id="findByMemberId" resultType="int" parameterType="int">
-        SELECT member_id
-          FROM tb_member
-         WHERE member_id = #{memberId}
-           AND member_status = 1;
-    </select>
-
     <select id="findByCoupleId" resultType="int" parameterType="int">
         SELECT couple_id
           FROM tb_couplelist


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
로그인 한 유저의 Id 를 가지고 유효성 검사를 거친 뒤, 수정 요청하는 일정의 데이터를 update 하는 기능입니다.

  <br/>

## 이미지 첨부
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/b9682c39-fab3-478d-b458-11ca245c2c0b" />

<br/>

## 🔧 앞으로의 과제

- 삭제 기능 (soft delete)

  <br/>

close #11 