### PR TITLE
feat(#19 ): 커플 일정 월별 조회 기능 추가

### DIFF
--- a/src/main/java/beyond/momentours/plan/command/application/controller/PlanController.java
+++ b/src/main/java/beyond/momentours/plan/command/application/controller/PlanController.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController("commandPlanController")
 @RequestMapping("api/plan")
 @Slf4j
@@ -73,4 +75,20 @@ public class PlanController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
         }
     }
+
+    @GetMapping("/schedules")
+    public ResponseEntity<?> getSchedules(@RequestParam int year, @RequestParam int month) {
+        log.info("스케줄 요청 year: {}, month: {}", year, month);
+        try {
+            List<PlanDTO> schedules = planService.getSchedules(year, month);
+            return ResponseEntity.status(HttpStatus.OK).body(schedules);
+        } catch (CommonException e) {
+            log.error("스케줄 조회 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
 }

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanService.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanService.java
@@ -3,6 +3,8 @@ package beyond.momentours.plan.command.application.service;
 import beyond.momentours.plan.command.application.dto.PlanDTO;
 import jakarta.transaction.Transactional;
 
+import java.util.List;
+
 public interface PlanService {
     @Transactional
     PlanDTO registerPlan(PlanDTO planDTO);
@@ -12,4 +14,6 @@ public interface PlanService {
 
     @Transactional
     PlanDTO deletePlan(Long planId);
+
+    List<PlanDTO> getSchedules(int year, int month);
 }

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanServiceImpl.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanServiceImpl.java
@@ -11,6 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Slf4j
 @Service("commandPlanService")
 @RequiredArgsConstructor
@@ -96,6 +100,27 @@ public class PlanServiceImpl implements PlanService {
         return planConverter.fromEntityToDTO(existingPlan);
     }
 
+    @Override
+    public List<PlanDTO> getSchedules(int year, int month) {
+        LocalDateTime planStartDate = LocalDateTime.of(year, month, 1, 0, 0, 0);
+        LocalDateTime planEndDate = planStartDate.withDayOfMonth(planStartDate.toLocalDate().lengthOfMonth())
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(59);
+
+        log.info("스케줄 조회 - 시작 날짜: {}, 종료 날짜: {}", planStartDate, planEndDate);
+
+//        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
+        Long memberId = 0L;
+        Long coupleId = planDAO.findByCoupleId(memberId);
+        log.info("memberId : {} , coupleId : {}", memberId, coupleId);
+
+        List<Plan> plans = planDAO.findByCoupleIdAndDateRange(coupleId, planStartDate, planEndDate);
+
+        return plans.stream()
+                .map(planConverter::fromEntityToDTO)
+                .toList();
+    }
 
     private void updatePlan(PlanDTO planDTO, Plan existingPlan) {
         if (planDTO.getPlanTitle() != null) existingPlan.updateTitle(planDTO.getPlanTitle());

--- a/src/main/java/beyond/momentours/plan/query/repository/PlanMapper.java
+++ b/src/main/java/beyond/momentours/plan/query/repository/PlanMapper.java
@@ -1,6 +1,10 @@
 package beyond.momentours.plan.query.repository;
 
+import beyond.momentours.plan.command.domain.aggregate.entity.Plan;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Mapper
 public interface PlanMapper {
@@ -8,4 +12,6 @@ public interface PlanMapper {
     Long findByCoupleId(Long memberId);
 
     Long findByCourseId(Long courseId);
+
+    List<Plan> findByCoupleIdAndDateRange(Long coupleId, LocalDateTime planStartDate, LocalDateTime planEndDate);
 }

--- a/src/main/resources/beyond/momentours/mapper/PlanMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/PlanMapper.xml
@@ -27,9 +27,18 @@
 
     <select id="findByCourseId" resultType="int" parameterType="int">
         SELECT course_id
-        FROM tb_date_course
-        WHERE course_id = #{courseId}
-        AND course_status = 1;
+          FROM tb_date_course
+         WHERE course_id = #{courseId}
+           AND course_status = 1;
+    </select>
+
+    <select id="findByCoupleIdAndDateRange" resultMap="planResultMap">
+        SELECT plan_id, plan_title, plan_content, plan_start_date, plan_end_date, plan_status, created_at, updated_at, member_id, couple_id, course_id
+          FROM tb_plan
+         WHERE couple_id = #{coupleId}
+           AND plan_start_date >= #{planStartDate}
+           AND plan_end_date <= #{planEndDate}
+           AND plan_status = 1;
     </select>
 
 </mapper>


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
- 시작 시간이 월마다 1일 00시 00분 00초 이후거나 종료 시간이 말일 23시 59분 59초기만 하다면 해당 일정 데이터를 가져와 조회하게 해주는 기능을 추가했습니다.
- 해당 월 별 달력을 조회할 때 화면에 띄워주기 위한 데이터로, 화면에 보여줄 때 만약 이전 달에 이어서 다음 달로도 이어진다면 말일을 기준으로 잘라져 보이게끔 하거나 정해야 할 것 같습니다.

  <br/>

## 이미지 첨부
추가로 xml 에서 <= 부분에 < 가 <> 과 같이 닫는 괄호가 필요하다는 의미로 빨간 줄이 있는데 실행하는데 문제는 없습니다.
<img width="530" alt="image" src="https://github.com/user-attachments/assets/91dd93e4-d509-4b5d-95bf-d7423f7d0083" />


<br/>

## 🔧 앞으로의 과제

- 특정 날짜짜 조회

  <br/>

close #19 