### PR TITLE
feat(32): 커플 삭제 기능 구현 및 converter 클래스 추가

### DIFF
--- a/src/main/java/beyond/momentours/couple/command/application/controller/CommandCoupleController.java
+++ b/src/main/java/beyond/momentours/couple/command/application/controller/CommandCoupleController.java
@@ -57,4 +57,11 @@ public class CommandCoupleController {
         CoupleProfileResponseVO responseVO = coupleConverter.fromDtoToCoupleVO(profileDTO);
         return ResponseDTO.ok(responseVO);
     }
+
+    // 커플 삭제하는 메서드
+    @PostMapping("/soft-delete/{coupleId}")
+    public ResponseDTO<?> deleteCouple(@PathVariable Long coupleId) {
+        CoupleListDTO coupleDTO = commandCoupleService.deleteCouple(coupleId);
+        return ResponseDTO.ok("성공적으로 삭제되었습니다.");
+    }
 }

--- a/src/main/java/beyond/momentours/couple/command/application/controller/CommandCoupleController.java
+++ b/src/main/java/beyond/momentours/couple/command/application/controller/CommandCoupleController.java
@@ -4,12 +4,14 @@ import beyond.momentours.common.ResponseDTO;
 import beyond.momentours.couple.command.application.dto.CoupleListDTO;
 import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
 import beyond.momentours.couple.command.application.dto.MatchingCodeDTO;
+import beyond.momentours.couple.command.application.mapper.CodeConverter;
+import beyond.momentours.couple.command.application.mapper.CoupleConverter;
 import beyond.momentours.couple.command.application.service.CommandCoupleService;
 import beyond.momentours.couple.command.application.service.CoupleMatchingService;
-import beyond.momentours.couple.command.domain.vo.CoupleListVO;
-import beyond.momentours.couple.command.domain.vo.CoupleProfileRequestVO;
-import beyond.momentours.couple.command.domain.vo.CoupleProfileResponseVO;
-import beyond.momentours.couple.command.domain.vo.MatchingCodeVO;
+import beyond.momentours.couple.command.domain.vo.response.CoupleListResponseVO;
+import beyond.momentours.couple.command.domain.vo.request.CoupleProfileRequestVO;
+import beyond.momentours.couple.command.domain.vo.response.CoupleProfileResponseVO;
+import beyond.momentours.couple.command.domain.vo.response.MatchingCodeResponseVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,53 +20,41 @@ import org.springframework.web.bind.annotation.*;
 public class CommandCoupleController {
     private final CommandCoupleService commandCoupleService;
     private final CoupleMatchingService coupleMatchingService;
+    private final CodeConverter codeConverter;
+    private final CoupleConverter coupleConverter;
 
     @Autowired
-    public CommandCoupleController(CommandCoupleService commandCoupleService, CoupleMatchingService coupleMatchingService) {
+    public CommandCoupleController(CommandCoupleService commandCoupleService,
+                                   CoupleMatchingService coupleMatchingService,
+                                   CodeConverter codeConverter,
+                                   CoupleConverter coupleConverter) {
         this.commandCoupleService = commandCoupleService;
         this.coupleMatchingService = coupleMatchingService;
+        this.codeConverter = codeConverter;
+        this.coupleConverter = coupleConverter;
     }
 
     // 매칭코드를 생성하는 controller method
     @PostMapping("/{userId}")
     public ResponseDTO<?> createMatchingCode(@PathVariable Long userId) {
-        MatchingCodeDTO matchingCode = coupleMatchingService.createMatchingCode(userId);
-        MatchingCodeVO matchingCodeVO = MatchingCodeVO.builder()
-                .id(matchingCode.getId())
-                .memberId(matchingCode.getMemberId())
-                .createdAt(matchingCode.getCreatedAt())
-                .matchingStatus(matchingCode.getMatchingStatus())
-                .build();
+        MatchingCodeDTO codeDTO = coupleMatchingService.createMatchingCode(userId);
+        MatchingCodeResponseVO matchingCodeVO = codeConverter.fromDtoToResponseVO(codeDTO);
         return ResponseDTO.ok(matchingCodeVO);
     }
+
     // 매칭코드로 인증하는 controller method
     @PostMapping("/authentication/{memberId}")
-    public ResponseDTO<?> authenticateMatchingCode(@PathVariable Long memberId, @RequestBody MatchingCodeVO matchingCodeVO) {
-       CoupleListDTO coupleListDTO =
-               coupleMatchingService.authenticationMatchingCode(matchingCodeVO.getId(), memberId);
-       CoupleListVO coupleListVO = CoupleListVO.builder()
-               .coupleId(coupleListDTO.getCoupleId())
-               .coupleName(coupleListDTO.getCoupleName())
-               .couplePhoto(coupleListDTO.getCouplePhoto())
-               .coupleStartDate(coupleListDTO.getCoupleStartDate())
-               .coupleMatchingStatus(coupleListDTO.getCoupleMatchingStatus())
-               .coupleStatus(coupleListDTO.getCoupleStatus())
-               .memberId1(coupleListDTO.getMemberId1())
-               .memberId2(coupleListDTO.getMemberId2())
-               .build();
-       return ResponseDTO.ok(coupleListVO);
+    public ResponseDTO<?> authenticateMatchingCode(@PathVariable Long memberId, @RequestBody MatchingCodeResponseVO matchingCodeVO) {
+       CoupleListDTO coupleDTO = coupleMatchingService.authenticationMatchingCode(matchingCodeVO.getId(), memberId);
+       CoupleListResponseVO responseVO = coupleConverter.fromDtoToCoupleVO(coupleDTO);
+       return ResponseDTO.ok(responseVO);
     }
 
     // 커플 정보를 입력하는 메서드
     @PatchMapping("/profile")
     public ResponseDTO<?> editCoupleProfile(CoupleProfileRequestVO requestVO) {
-        CoupleProfileDTO profileDTO = commandCoupleService.editProfile(requestVO);
-        CoupleProfileResponseVO responseVO = CoupleProfileResponseVO.builder()
-                .coupleId(profileDTO.getCoupleId())
-                .coupleName(profileDTO.getCoupleName())
-                .couplePhoto(profileDTO.getCouplePhoto())
-                .coupleStartDate(profileDTO.getCoupleStartDate())
-                .build();
+        CoupleProfileDTO profileDTO = commandCoupleService.updateProfile(requestVO);
+        CoupleProfileResponseVO responseVO = coupleConverter.fromDtoToCoupleVO(profileDTO);
         return ResponseDTO.ok(responseVO);
     }
 }

--- a/src/main/java/beyond/momentours/couple/command/application/mapper/CodeConverter.java
+++ b/src/main/java/beyond/momentours/couple/command/application/mapper/CodeConverter.java
@@ -1,0 +1,27 @@
+package beyond.momentours.couple.command.application.mapper;
+
+import beyond.momentours.couple.command.application.dto.MatchingCodeDTO;
+import beyond.momentours.couple.command.domain.aggregate.entity.MatchingCode;
+import beyond.momentours.couple.command.domain.vo.response.MatchingCodeResponseVO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CodeConverter {
+    public MatchingCodeDTO fromCodeToDto(MatchingCode code) {
+        return MatchingCodeDTO.builder()
+                .id(code.getId())
+                .memberId(code.getMemberId())
+                .createdAt(code.getCreatedAt())
+                .matchingStatus(code.getMatchingStatus())
+                .build();
+    }
+
+    public MatchingCodeResponseVO fromDtoToResponseVO(MatchingCodeDTO dto) {
+        return MatchingCodeResponseVO.builder()
+                .id(dto.getId())
+                .memberId(dto.getMemberId())
+                .createdAt(dto.getCreatedAt())
+                .matchingStatus(dto.getMatchingStatus())
+                .build();
+    }
+}

--- a/src/main/java/beyond/momentours/couple/command/application/mapper/CoupleConverter.java
+++ b/src/main/java/beyond/momentours/couple/command/application/mapper/CoupleConverter.java
@@ -1,0 +1,55 @@
+package beyond.momentours.couple.command.application.mapper;
+
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
+import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
+import beyond.momentours.couple.command.domain.vo.response.CoupleListResponseVO;
+import beyond.momentours.couple.command.domain.vo.response.CoupleProfileResponseVO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CoupleConverter {
+    public CoupleListDTO fromEntityToCoupleDTO(CoupleList couple) {
+        return CoupleListDTO.builder()
+                .coupleId(couple.getCoupleId())
+                .coupleName(couple.getCoupleName())
+                .couplePhoto(couple.getCouplePhoto())
+                .coupleStartDate(couple.getCoupleStartDate())
+                .coupleMatchingStatus(couple.getCoupleMatchingStatus())
+                .coupleStatus(couple.getCoupleStatus())
+                .memberId1(couple.getMemberId1())
+                .memberId2(couple.getMemberId2())
+                .build();
+    }
+
+    public CoupleProfileDTO fromEntityToProfileDTO(CoupleList couple) {
+        return CoupleProfileDTO.builder()
+                .coupleId(couple.getCoupleId())
+                .coupleName(couple.getCoupleName())
+                .couplePhoto(couple.getCouplePhoto())
+                .coupleStartDate(couple.getCoupleStartDate())
+                .build();
+    }
+
+    public CoupleListResponseVO fromDtoToCoupleVO(CoupleListDTO dto) {
+        return CoupleListResponseVO.builder()
+                .coupleId(dto.getCoupleId())
+                .coupleName(dto.getCoupleName())
+                .couplePhoto(dto.getCouplePhoto())
+                .coupleStartDate(dto.getCoupleStartDate())
+                .coupleMatchingStatus(dto.getCoupleMatchingStatus())
+                .coupleStatus(dto.getCoupleStatus())
+                .memberId1(dto.getMemberId1())
+                .memberId2(dto.getMemberId2())
+                .build();
+    }
+
+    public CoupleProfileResponseVO fromDtoToCoupleVO(CoupleProfileDTO dto) {
+        return CoupleProfileResponseVO.builder()
+                .coupleId(dto.getCoupleId())
+                .coupleName(dto.getCoupleName())
+                .couplePhoto(dto.getCouplePhoto())
+                .coupleStartDate(dto.getCoupleStartDate())
+                .build();
+    }
+}

--- a/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleService.java
+++ b/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleService.java
@@ -1,9 +1,12 @@
 package beyond.momentours.couple.command.application.service;
 
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
 import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
 import beyond.momentours.couple.command.domain.vo.request.CoupleProfileRequestVO;
 
 public interface CommandCoupleService {
 
     CoupleProfileDTO updateProfile(CoupleProfileRequestVO requestVO);
+
+    CoupleListDTO deleteCouple(Long coupleId);
 }

--- a/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleService.java
+++ b/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleService.java
@@ -1,9 +1,9 @@
 package beyond.momentours.couple.command.application.service;
 
 import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
-import beyond.momentours.couple.command.domain.vo.CoupleProfileRequestVO;
+import beyond.momentours.couple.command.domain.vo.request.CoupleProfileRequestVO;
 
 public interface CommandCoupleService {
 
-    CoupleProfileDTO editProfile(CoupleProfileRequestVO requestVO);
+    CoupleProfileDTO updateProfile(CoupleProfileRequestVO requestVO);
 }

--- a/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImpl.java
+++ b/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImpl.java
@@ -2,6 +2,7 @@ package beyond.momentours.couple.command.application.service;
 
 import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
 import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
 import beyond.momentours.couple.command.application.mapper.CoupleConverter;
 import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
@@ -32,7 +33,19 @@ public class CommandCoupleServiceImpl implements CommandCoupleService {
         CoupleList existingCouple = coupleRepository.findCoupleListByCoupleId(requestVO.getCoupleId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COUPLE));
         existingCouple.update(requestVO);
+        coupleRepository.save(existingCouple);
         log.info("수정된 커플 객체 정보: {}", existingCouple);
         return coupleConverter.fromEntityToProfileDTO(existingCouple);
+    }
+
+    @Override
+    public CoupleListDTO deleteCouple(Long coupleId) {
+        log.info("deleteCouple 메서드 시작, coupleId: {}", coupleId);
+        CoupleList existingCouple = coupleRepository.findCoupleListByCoupleId(coupleId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COUPLE));
+        existingCouple.delete();
+        coupleRepository.save(existingCouple);
+        log.info("삭제된 커플 객체 정보: {}", existingCouple);
+        return coupleConverter.fromEntityToCoupleDTO(existingCouple);
     }
 }

--- a/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImpl.java
+++ b/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImpl.java
@@ -30,7 +30,7 @@ public class CommandCoupleServiceImpl implements CommandCoupleService {
     @Override
     public CoupleProfileDTO updateProfile(CoupleProfileRequestVO requestVO) {
         log.info("couple profile 수정 메서드 시작, requestVO: {}", requestVO);
-        CoupleList existingCouple = coupleRepository.findCoupleListByCoupleId(requestVO.getCoupleId())
+        CoupleList existingCouple = coupleRepository.findCoupleListByCoupleIdAndCoupleStatusIsTrue(requestVO.getCoupleId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COUPLE));
         existingCouple.update(requestVO);
         coupleRepository.save(existingCouple);
@@ -41,7 +41,7 @@ public class CommandCoupleServiceImpl implements CommandCoupleService {
     @Override
     public CoupleListDTO deleteCouple(Long coupleId) {
         log.info("deleteCouple 메서드 시작, coupleId: {}", coupleId);
-        CoupleList existingCouple = coupleRepository.findCoupleListByCoupleId(coupleId)
+        CoupleList existingCouple = coupleRepository.findCoupleListByCoupleIdAndCoupleStatusIsTrue(coupleId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COUPLE));
         existingCouple.delete();
         coupleRepository.save(existingCouple);

--- a/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImpl.java
+++ b/src/main/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImpl.java
@@ -3,9 +3,10 @@ package beyond.momentours.couple.command.application.service;
 import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.common.exception.ErrorCode;
 import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
+import beyond.momentours.couple.command.application.mapper.CoupleConverter;
 import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
 import beyond.momentours.couple.command.domain.repository.CoupleRepository;
-import beyond.momentours.couple.command.domain.vo.CoupleProfileRequestVO;
+import beyond.momentours.couple.command.domain.vo.request.CoupleProfileRequestVO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,24 +17,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class CommandCoupleServiceImpl implements CommandCoupleService {
     private final CoupleRepository coupleRepository;
+    private final CoupleConverter coupleConverter;
 
     @Autowired
-    public CommandCoupleServiceImpl(CoupleRepository coupleRepository) {
+    public CommandCoupleServiceImpl(CoupleRepository coupleRepository,
+                                    CoupleConverter coupleConverter) {
         this.coupleRepository = coupleRepository;
+        this.coupleConverter = coupleConverter;
     }
 
     @Override
-    public CoupleProfileDTO editProfile(CoupleProfileRequestVO requestVO) {
+    public CoupleProfileDTO updateProfile(CoupleProfileRequestVO requestVO) {
         log.info("couple profile 수정 메서드 시작, requestVO: {}", requestVO);
         CoupleList existingCouple = coupleRepository.findCoupleListByCoupleId(requestVO.getCoupleId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COUPLE));
         existingCouple.update(requestVO);
         log.info("수정된 커플 객체 정보: {}", existingCouple);
-        return CoupleProfileDTO.builder()
-                .coupleId(existingCouple.getCoupleId())
-                .coupleName(existingCouple.getCoupleName())
-                .couplePhoto(existingCouple.getCouplePhoto())
-                .coupleStartDate(existingCouple.getCoupleStartDate())
-                .build();
+        return coupleConverter.fromEntityToProfileDTO(existingCouple);
     }
 }

--- a/src/main/java/beyond/momentours/couple/command/domain/aggregate/entity/CoupleList.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/aggregate/entity/CoupleList.java
@@ -45,7 +45,7 @@ public class CoupleList {
         this.memberId1 = memberId1;
         this.memberId2 = memberId2;
         this.coupleMatchingStatus = CoupleMatchingStatus.AUTHENTICATED;
-        this.coupleStatus = Boolean.FALSE;
+        this.coupleStatus = Boolean.TRUE;
         this.coupleStartDate = LocalDateTime.now();
         this.coupleName = memberName1 +" " +memberName2;
     }
@@ -60,5 +60,9 @@ public class CoupleList {
         if (requestVO.getCoupleStartDate() != null) {
             this.coupleStartDate = requestVO.getCoupleStartDate();
         }
+    }
+
+    public void delete() {
+        this.coupleStatus = Boolean.FALSE;
     }
 }

--- a/src/main/java/beyond/momentours/couple/command/domain/aggregate/entity/CoupleList.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/aggregate/entity/CoupleList.java
@@ -1,6 +1,6 @@
 package beyond.momentours.couple.command.domain.aggregate.entity;
 
-import beyond.momentours.couple.command.domain.vo.CoupleProfileRequestVO;
+import beyond.momentours.couple.command.domain.vo.request.CoupleProfileRequestVO;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/beyond/momentours/couple/command/domain/repository/CoupleRepository.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/repository/CoupleRepository.java
@@ -14,5 +14,5 @@ public interface CoupleRepository extends JpaRepository<CoupleList, Long> {
             "WHERE (c.memberId1 = :memberId OR c.memberId2 = :memberId) " +
             "AND c.coupleStatus = true")
     Optional<CoupleList> findActiveCoupleByMemberId(@Param("memberId") Long memberId);
-    Optional<CoupleList> findCoupleListByCoupleId(Long coupleId);
+    Optional<CoupleList> findCoupleListByCoupleIdAndCoupleStatusIsTrue(Long coupleId);
 }

--- a/src/main/java/beyond/momentours/couple/command/domain/vo/request/CoupleProfileRequestVO.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/vo/request/CoupleProfileRequestVO.java
@@ -1,4 +1,4 @@
-package beyond.momentours.couple.command.domain.vo;
+package beyond.momentours.couple.command.domain.vo.request;
 
 import lombok.*;
 

--- a/src/main/java/beyond/momentours/couple/command/domain/vo/response/CoupleListResponseVO.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/vo/response/CoupleListResponseVO.java
@@ -1,4 +1,4 @@
-package beyond.momentours.couple.command.domain.vo;
+package beyond.momentours.couple.command.domain.vo.response;
 
 import beyond.momentours.couple.command.domain.aggregate.entity.CoupleMatchingStatus;
 import lombok.*;
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
-public class CoupleListVO {
+public class CoupleListResponseVO {
     private Long coupleId;
     private String coupleName;
     private String couplePhoto;

--- a/src/main/java/beyond/momentours/couple/command/domain/vo/response/CoupleProfileResponseVO.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/vo/response/CoupleProfileResponseVO.java
@@ -1,4 +1,4 @@
-package beyond.momentours.couple.command.domain.vo;
+package beyond.momentours.couple.command.domain.vo.response;
 
 import lombok.*;
 

--- a/src/main/java/beyond/momentours/couple/command/domain/vo/response/MatchingCodeResponseVO.java
+++ b/src/main/java/beyond/momentours/couple/command/domain/vo/response/MatchingCodeResponseVO.java
@@ -1,4 +1,4 @@
-package beyond.momentours.couple.command.domain.vo;
+package beyond.momentours.couple.command.domain.vo.response;
 
 import beyond.momentours.couple.command.domain.aggregate.entity.MatchingStatus;
 import lombok.*;
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @ToString
 @EqualsAndHashCode
 @Builder
-public class MatchingCodeVO {
+public class MatchingCodeResponseVO {
     private String id;
     private Long memberId;
     private LocalDateTime createdAt;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
+
+  jpa:
+    show-sql: true
+    database: mysql
+    properties:
+      hibernate:
+        format_sql: true
+    generate-ddl: false

--- a/src/test/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImplTests.java
+++ b/src/test/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImplTests.java
@@ -55,7 +55,7 @@ class CommandCoupleServiceImplTests {
                 2L
         );
 
-        when(coupleRepository.findCoupleListByCoupleId(requestVO.getCoupleId()))
+        when(coupleRepository.findCoupleListByCoupleIdAndCoupleStatusIsTrue(requestVO.getCoupleId()))
                 .thenReturn(Optional.of(testCouple));
 
         CoupleProfileDTO expectedDTO = new CoupleProfileDTO();
@@ -67,7 +67,7 @@ class CommandCoupleServiceImplTests {
 
         // then
         verify(coupleRepository, times(1))
-                .findCoupleListByCoupleId(requestVO.getCoupleId());
+                .findCoupleListByCoupleIdAndCoupleStatusIsTrue(requestVO.getCoupleId());
 
         assertEquals(testCouple.getCoupleName(), requestVO.getCoupleName());
         assertEquals(testCouple.getCouplePhoto(), requestVO.getCouplePhoto());
@@ -94,7 +94,7 @@ class CommandCoupleServiceImplTests {
                 2L
         );
 
-        when(coupleRepository.findCoupleListByCoupleId(coupleId))
+        when(coupleRepository.findCoupleListByCoupleIdAndCoupleStatusIsTrue(coupleId))
                 .thenReturn(Optional.of(testCouple));
 
         CoupleListDTO expectedDTO = new CoupleListDTO();
@@ -115,8 +115,9 @@ class CommandCoupleServiceImplTests {
 
         // then
         verify(coupleRepository, times(1))
-                .findCoupleListByCoupleId(coupleId);
+                .findCoupleListByCoupleIdAndCoupleStatusIsTrue(coupleId);
 
+        assertEquals(testCouple.getCoupleStatus(), false);
         assertEquals(deletedCouple.getCoupleStatus(), false);
         assertEquals(expectedDTO, deletedCouple);
     }

--- a/src/test/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImplTests.java
+++ b/src/test/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImplTests.java
@@ -1,5 +1,6 @@
 package beyond.momentours.couple.command.application.service;
 
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
 import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
 import beyond.momentours.couple.command.application.mapper.CoupleConverter;
 import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
@@ -48,7 +49,7 @@ class CommandCoupleServiceImplTests {
                 "기존 이름",
                 "기존 사진",
                 LocalDateTime.of(2024, 12, 12, 0, 0),
-                false,
+                true,
                 CoupleMatchingStatus.PROFILE_COMPLETED,
                 1L,
                 2L
@@ -74,5 +75,49 @@ class CommandCoupleServiceImplTests {
 
         verify(converter, times(1)).fromEntityToProfileDTO(testCouple);
         assertEquals(expectedDTO, result);
+    }
+
+    @Test
+    @DisplayName("커플 삭제 테스트")
+    void deleteCouple() {
+        // given
+        Long coupleId = 1L;
+
+        CoupleList testCouple = new CoupleList(
+                1L,
+                "기존 이름",
+                "기존 사진",
+                LocalDateTime.of(2024, 12, 12, 0, 0),
+                true,
+                CoupleMatchingStatus.PROFILE_COMPLETED,
+                1L,
+                2L
+        );
+
+        when(coupleRepository.findCoupleListByCoupleId(coupleId))
+                .thenReturn(Optional.of(testCouple));
+
+        CoupleListDTO expectedDTO = new CoupleListDTO();
+        expectedDTO.setCoupleId(1L);
+        expectedDTO.setCoupleName("기존 이름");
+        expectedDTO.setCouplePhoto("기존 사진");
+        expectedDTO.setCoupleStartDate(LocalDateTime.of(2024, 12, 12, 0, 0));
+        expectedDTO.setCoupleStatus(false);
+        expectedDTO.setCoupleMatchingStatus(CoupleMatchingStatus.PROFILE_COMPLETED);
+        expectedDTO.setMemberId1(1L);
+        expectedDTO.setMemberId2(2L);
+
+        when(converter.fromEntityToCoupleDTO(any(CoupleList.class)))
+                .thenReturn(expectedDTO);
+
+        // when
+        CoupleListDTO deletedCouple = coupleService.deleteCouple(coupleId);
+
+        // then
+        verify(coupleRepository, times(1))
+                .findCoupleListByCoupleId(coupleId);
+
+        assertEquals(deletedCouple.getCoupleStatus(), false);
+        assertEquals(expectedDTO, deletedCouple);
     }
 }

--- a/src/test/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImplTests.java
+++ b/src/test/java/beyond/momentours/couple/command/application/service/CommandCoupleServiceImplTests.java
@@ -1,0 +1,78 @@
+package beyond.momentours.couple.command.application.service;
+
+import beyond.momentours.couple.command.application.dto.CoupleProfileDTO;
+import beyond.momentours.couple.command.application.mapper.CoupleConverter;
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleMatchingStatus;
+import beyond.momentours.couple.command.domain.repository.CoupleRepository;
+import beyond.momentours.couple.command.domain.vo.request.CoupleProfileRequestVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class CommandCoupleServiceImplTests {
+    @Mock
+    private CoupleRepository coupleRepository;
+
+    @Mock
+    private CoupleConverter converter;
+
+    @InjectMocks
+    private CommandCoupleServiceImpl coupleService;
+
+    @Test
+    @DisplayName("커플 프로필 수정 테스트")
+    void updateCoupleProfile() {
+        // given
+        CoupleProfileRequestVO requestVO = new CoupleProfileRequestVO();
+        requestVO.setCoupleId(1L);
+        requestVO.setCoupleName("새로운 커플 이름");
+        requestVO.setCouplePhoto("새로운 커플 사진");
+        requestVO.setCoupleStartDate(LocalDateTime.of(2025, 1, 1, 0, 0));
+
+        CoupleList testCouple = new CoupleList(
+                1L,
+                "기존 이름",
+                "기존 사진",
+                LocalDateTime.of(2024, 12, 12, 0, 0),
+                false,
+                CoupleMatchingStatus.PROFILE_COMPLETED,
+                1L,
+                2L
+        );
+
+        when(coupleRepository.findCoupleListByCoupleId(requestVO.getCoupleId()))
+                .thenReturn(Optional.of(testCouple));
+
+        CoupleProfileDTO expectedDTO = new CoupleProfileDTO();
+        when(converter.fromEntityToProfileDTO(any(CoupleList.class)))
+                .thenReturn(expectedDTO);
+
+        // when
+        CoupleProfileDTO result = coupleService.updateProfile(requestVO);
+
+        // then
+        verify(coupleRepository, times(1))
+                .findCoupleListByCoupleId(requestVO.getCoupleId());
+
+        assertEquals(testCouple.getCoupleName(), requestVO.getCoupleName());
+        assertEquals(testCouple.getCouplePhoto(), requestVO.getCouplePhoto());
+        assertEquals(testCouple.getCoupleStartDate(), requestVO.getCoupleStartDate());
+
+        verify(converter, times(1)).fromEntityToProfileDTO(testCouple);
+        assertEquals(expectedDTO, result);
+    }
+}


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 커플 삭제 기능을 구현하였습니다.  커플과 매칭 코드 클래스를 위한 converter 클래스를 추가했습니다. 커플 삭제 테스트 기능을 구현했습니다.

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- mybatis를 활용한 특정 커플 조회 기능을 구현할 예정입니다. 커플 로그에 대한 설계를 어떻게 해야할지 고민해보겠습니다.

  <br/>
