### PR TITLE
feat(36): 커플 번호로 활성화된 특정 커플 조회 기능 추가 + 회원 번호로 활성화된 특정 커플 조회 기능 추가

### DIFF
--- a/src/main/java/beyond/momentours/couple/query/controller/QueryCoupleController.java
+++ b/src/main/java/beyond/momentours/couple/query/controller/QueryCoupleController.java
@@ -1,0 +1,33 @@
+package beyond.momentours.couple.query.controller;
+
+import beyond.momentours.common.ResponseDTO;
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
+import beyond.momentours.couple.command.application.mapper.CoupleConverter;
+import beyond.momentours.couple.command.domain.vo.response.CoupleListResponseVO;
+import beyond.momentours.couple.query.service.QueryCoupleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/couple")
+public class QueryCoupleController {
+    private final QueryCoupleService coupleService;
+    private final CoupleConverter converter;
+
+    @Autowired
+    public QueryCoupleController (QueryCoupleService coupleService,
+                                  CoupleConverter coupleConverter) {
+        this.coupleService = coupleService;
+        this.converter = coupleConverter;
+    }
+
+    @GetMapping("/{coupleId}")
+    public ResponseDTO<?> getCoupleById(@PathVariable("coupleId") Long coupleId) {
+        CoupleListDTO coupleListDTO = coupleService.getCoupleById(coupleId);
+        CoupleListResponseVO responseVO = converter.fromDtoToCoupleVO(coupleListDTO);
+        return ResponseDTO.ok(responseVO);
+    }
+}

--- a/src/main/java/beyond/momentours/couple/query/controller/QueryCoupleController.java
+++ b/src/main/java/beyond/momentours/couple/query/controller/QueryCoupleController.java
@@ -26,8 +26,13 @@ public class QueryCoupleController {
 
     @GetMapping("/{coupleId}")
     public ResponseDTO<?> getCoupleById(@PathVariable("coupleId") Long coupleId) {
-        CoupleListDTO coupleListDTO = coupleService.getCoupleById(coupleId);
-        CoupleListResponseVO responseVO = converter.fromDtoToCoupleVO(coupleListDTO);
-        return ResponseDTO.ok(responseVO);
+        CoupleListDTO coupleListDTO = coupleService.getCoupleByCoupleId(coupleId);
+        return ResponseDTO.ok(converter.fromDtoToCoupleVO(coupleListDTO));
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseDTO<?> getCoupleByMemberId(@PathVariable("memberId") Long memberId) {
+        CoupleListDTO coupleListDTO = coupleService.getCoupleByMemberId(memberId);
+        return ResponseDTO.ok(converter.fromDtoToCoupleVO(coupleListDTO));
     }
 }

--- a/src/main/java/beyond/momentours/couple/query/repository/CoupleMapper.java
+++ b/src/main/java/beyond/momentours/couple/query/repository/CoupleMapper.java
@@ -6,4 +6,6 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface CoupleMapper {
     CoupleList getCoupleByCoupleId(Long coupleId);
+
+    CoupleList getCoupleByMemberId(Long memberId);
 }

--- a/src/main/java/beyond/momentours/couple/query/repository/CoupleMapper.java
+++ b/src/main/java/beyond/momentours/couple/query/repository/CoupleMapper.java
@@ -1,2 +1,9 @@
-package beyond.momentours.couple.query.repository;public interface CoupleMapper {
+package beyond.momentours.couple.query.repository;
+
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CoupleMapper {
+    CoupleList getCoupleByCoupleId(Long coupleId);
 }

--- a/src/main/java/beyond/momentours/couple/query/service/QueryCoupleService.java
+++ b/src/main/java/beyond/momentours/couple/query/service/QueryCoupleService.java
@@ -1,0 +1,7 @@
+package beyond.momentours.couple.query.service;
+
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
+
+public interface QueryCoupleService {
+    CoupleListDTO getCoupleById(Long coupleId);
+}

--- a/src/main/java/beyond/momentours/couple/query/service/QueryCoupleService.java
+++ b/src/main/java/beyond/momentours/couple/query/service/QueryCoupleService.java
@@ -3,5 +3,7 @@ package beyond.momentours.couple.query.service;
 import beyond.momentours.couple.command.application.dto.CoupleListDTO;
 
 public interface QueryCoupleService {
-    CoupleListDTO getCoupleById(Long coupleId);
+    CoupleListDTO getCoupleByCoupleId(Long coupleId);
+
+    CoupleListDTO getCoupleByMemberId(Long memberId);
 }

--- a/src/main/java/beyond/momentours/couple/query/service/QueryCoupleServiceImpl.java
+++ b/src/main/java/beyond/momentours/couple/query/service/QueryCoupleServiceImpl.java
@@ -25,8 +25,17 @@ public class QueryCoupleServiceImpl implements QueryCoupleService {
     }
 
     @Override
-    public CoupleListDTO getCoupleById(Long coupleId) {
+    public CoupleListDTO getCoupleByCoupleId(Long coupleId) {
         CoupleList existingCouple = coupleMapper.getCoupleByCoupleId(coupleId);
+        if (existingCouple == null) {
+            throw new CommonException(ErrorCode.NOT_FOUND_COUPLE);
+        }
+        return converter.fromEntityToCoupleDTO(existingCouple);
+    }
+
+    @Override
+    public CoupleListDTO getCoupleByMemberId(Long memberId) {
+        CoupleList existingCouple = coupleMapper.getCoupleByMemberId(memberId);
         if (existingCouple == null) {
             throw new CommonException(ErrorCode.NOT_FOUND_COUPLE);
         }

--- a/src/main/java/beyond/momentours/couple/query/service/QueryCoupleServiceImpl.java
+++ b/src/main/java/beyond/momentours/couple/query/service/QueryCoupleServiceImpl.java
@@ -1,0 +1,35 @@
+package beyond.momentours.couple.query.service;
+
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
+import beyond.momentours.couple.command.application.mapper.CoupleConverter;
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
+import beyond.momentours.couple.query.repository.CoupleMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@Transactional
+public class QueryCoupleServiceImpl implements QueryCoupleService {
+    private final CoupleMapper coupleMapper;
+    private final CoupleConverter converter;
+
+    @Autowired
+    public QueryCoupleServiceImpl(CoupleMapper coupleMapper, CoupleConverter converter) {
+        this.coupleMapper = coupleMapper;
+        this.converter = converter;
+    }
+
+    @Override
+    public CoupleListDTO getCoupleById(Long coupleId) {
+        CoupleList existingCouple = coupleMapper.getCoupleByCoupleId(coupleId);
+        if (existingCouple == null) {
+            throw new CommonException(ErrorCode.NOT_FOUND_COUPLE);
+        }
+        return converter.fromEntityToCoupleDTO(existingCouple);
+    }
+}

--- a/src/main/resources/beyond/momentours/mapper/CoupleMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/CoupleMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="beyond.momentours.couple.query.repository.CoupleMapper">
+    <resultMap id="coupleResultMap" type="beyond.momentours.couple.command.domain.aggregate.entity.CoupleList">
+        <id property="coupleId" column="couple_id"/>
+        <result property="coupleName" column="couple_name"/>
+        <result property="couplePhoto" column="couple_photo"/>
+        <result property="coupleStartDate" column="couple_start_date"/>
+        <result property="coupleStatus" column="couple_status"/>
+        <result property="coupleMatchingStatus" column="couple_matching_status"/>
+        <result property="memberId1" column="member_id1"/>
+        <result property="memberId2" column="member_id2"/>
+    </resultMap>
+
+    <select id="getCoupleByCoupleId" resultMap="coupleResultMap" parameterType="long">
+        SELECT
+            c.couple_id,
+            c.couple_name,
+            c.couple_photo,
+            c.couple_start_date,
+            c.couple_status,
+            c.couple_matching_status,
+            c.member_id1,
+            c.member_id2
+        FROM tb_couple_list c
+        WHERE c.couple_id = #{coupleId}
+        AND c.couple_status = 1
+    </select>
+</mapper>

--- a/src/main/resources/beyond/momentours/mapper/CoupleMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/CoupleMapper.xml
@@ -29,4 +29,19 @@
         WHERE c.couple_id = #{coupleId}
         AND c.couple_status = 1
     </select>
+
+    <select id="getCoupleByMemberId" resultMap="coupleResultMap" parameterType="long">
+        SELECT
+            c.couple_id,
+            c.couple_name,
+            c.couple_photo,
+            c.couple_start_date,
+            c.couple_status,
+            c.couple_matching_status,
+            c.member_id1,
+            c.member_id2
+        FROM tb_couple_list c
+        WHERE c.couple_status = 1
+        AND (member_id1 = #{memberId} OR member_id2 = #{memberId})
+    </select>
 </mapper>

--- a/src/test/java/beyond/momentours/couple/query/service/QueryCoupleServiceImplTests.java
+++ b/src/test/java/beyond/momentours/couple/query/service/QueryCoupleServiceImplTests.java
@@ -1,0 +1,74 @@
+package beyond.momentours.couple.query.service;
+
+import beyond.momentours.couple.command.application.dto.CoupleListDTO;
+import beyond.momentours.couple.command.application.mapper.CoupleConverter;
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleList;
+import beyond.momentours.couple.command.domain.aggregate.entity.CoupleMatchingStatus;
+import beyond.momentours.couple.query.repository.CoupleMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QueryCoupleServiceImplTests {
+    @Mock
+    private CoupleMapper coupleMapper;
+
+    @Mock
+    private CoupleConverter converter;
+
+    @InjectMocks
+    private QueryCoupleServiceImpl coupleService;
+
+    @Test
+    @DisplayName("특정 커플번호로 활성상태인 커플 조회 테스트")
+    void getActivatedCoupleById() {
+        // given
+        Long coupleId = 1L;
+        LocalDateTime startDate = LocalDateTime.of(2024, 12, 12, 0, 0);
+        CoupleList testCouple = new CoupleList(
+                1L,
+                "테스트 커플 이름",
+                "test_photo.png",
+                startDate,
+                true,
+                CoupleMatchingStatus.PROFILE_COMPLETED,
+                1L,
+                2L
+        );
+
+        when(coupleMapper.getCoupleByCoupleId(coupleId)).thenReturn(testCouple);
+
+        CoupleListDTO expectedDTO = CoupleListDTO.builder()
+                .coupleId(coupleId)
+                .coupleName("테스트 커플 이름")
+                .couplePhoto("test_photo.png")
+                .coupleStartDate(startDate)
+                .coupleStatus(true)
+                .coupleMatchingStatus(CoupleMatchingStatus.PROFILE_COMPLETED)
+                .memberId1(1L)
+                .memberId2(2L)
+                .build();
+        when(converter.fromEntityToCoupleDTO(any(CoupleList.class))).thenReturn(expectedDTO);
+
+        // when
+        CoupleListDTO result = coupleService.getCoupleById(coupleId);
+
+        // then
+        verify(coupleMapper, times(1)).getCoupleByCoupleId(coupleId);
+        verify(converter, times(1)).fromEntityToCoupleDTO(any(CoupleList.class));
+        assertNotNull(result);
+        assertEquals(result, expectedDTO);
+        assertEquals(result.getCoupleId(), coupleId);
+        assertEquals(result.getCoupleStatus(), true);
+    }
+}

--- a/src/test/java/beyond/momentours/couple/query/service/QueryCoupleServiceImplTests.java
+++ b/src/test/java/beyond/momentours/couple/query/service/QueryCoupleServiceImplTests.java
@@ -30,7 +30,7 @@ class QueryCoupleServiceImplTests {
     private QueryCoupleServiceImpl coupleService;
 
     @Test
-    @DisplayName("특정 커플번호로 활성상태인 커플 조회 테스트")
+    @DisplayName("특정 커플번호로 활성 상태인 커플 조회 테스트")
     void getActivatedCoupleById() {
         // given
         Long coupleId = 1L;
@@ -45,7 +45,6 @@ class QueryCoupleServiceImplTests {
                 1L,
                 2L
         );
-
         when(coupleMapper.getCoupleByCoupleId(coupleId)).thenReturn(testCouple);
 
         CoupleListDTO expectedDTO = CoupleListDTO.builder()
@@ -61,7 +60,7 @@ class QueryCoupleServiceImplTests {
         when(converter.fromEntityToCoupleDTO(any(CoupleList.class))).thenReturn(expectedDTO);
 
         // when
-        CoupleListDTO result = coupleService.getCoupleById(coupleId);
+        CoupleListDTO result = coupleService.getCoupleByCoupleId(coupleId);
 
         // then
         verify(coupleMapper, times(1)).getCoupleByCoupleId(coupleId);
@@ -69,6 +68,48 @@ class QueryCoupleServiceImplTests {
         assertNotNull(result);
         assertEquals(result, expectedDTO);
         assertEquals(result.getCoupleId(), coupleId);
+        assertEquals(result.getCoupleStatus(), true);
+    }
+
+    @Test
+    @DisplayName("회원 번호로 활성 상태인 특정 커플 조회")
+    void getActivatedCoupleByMemberId() {
+        // given
+        Long memberId = 1L;
+        LocalDateTime startDate = LocalDateTime.of(2024, 12, 12, 0, 0);
+        CoupleList testCouple = new CoupleList(
+                1L,
+                "테스트 커플 이름",
+                "test_photo.png",
+                startDate,
+                true,
+                CoupleMatchingStatus.PROFILE_COMPLETED,
+                1L,
+                2L
+        );
+        when(coupleMapper.getCoupleByMemberId(memberId)).thenReturn(testCouple);
+
+        CoupleListDTO expectedDTO = CoupleListDTO.builder()
+                .coupleId(1L)
+                .coupleName("테스트 커플 이름")
+                .couplePhoto("test_photo.png")
+                .coupleStartDate(startDate)
+                .coupleStatus(true)
+                .coupleMatchingStatus(CoupleMatchingStatus.PROFILE_COMPLETED)
+                .memberId1(memberId)
+                .memberId2(2L)
+                .build();
+        when(converter.fromEntityToCoupleDTO(any(CoupleList.class))).thenReturn(expectedDTO);
+
+        // when
+        CoupleListDTO result = coupleService.getCoupleByMemberId(memberId);
+
+        // then
+        verify(coupleMapper, times(1)).getCoupleByMemberId(memberId);
+        verify(converter, times(1)).fromEntityToCoupleDTO(any(CoupleList.class));
+        assertNotNull(result);
+        assertEquals(result, expectedDTO);
+        assertEquals(result.getMemberId1(), memberId);
         assertEquals(result.getCoupleStatus(), true);
     }
 }


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
  Mybatis를 이용해서 커플 번호로 활성화된(coupleStatus == 1) 커플을 조회하는 기능을 구현했습니다.
  Mybatis를 이용하여 회원 번호로 활성화된(coupleStatus == 1) 커플을 조회하는 기능을 구현했습니다.

  <br/>

## 이미지 첨부
<img width="908" alt="image" src="https://github.com/user-attachments/assets/9a4cf4de-64dc-45fe-a4f9-879d87a78dda" />

<img width="908" alt="image" src="https://github.com/user-attachments/assets/9c6761ff-3577-46f2-9faa-69cb08d341c3" />

<br/>

## 🔧 앞으로의 과제

- 커플로그 쪽 백엔드를 구현하기 위해서 사용할 프레임 워크 공부 및 프론트를 위한 react + react.native를 공부할까합니다.

  <br/>
