### PR TITLE
feat(#40): 대댓글 엔터티 추가 및 대댓글 CRUD 추가

### DIFF
--- a/src/main/java/beyond/momentours/comment/query/repository/CommentMapper.java
+++ b/src/main/java/beyond/momentours/comment/query/repository/CommentMapper.java
@@ -1,7 +1,10 @@
 package beyond.momentours.comment.query.repository;
 
+import beyond.momentours.comment.command.domain.aggregate.entity.Comment;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface CommentMapper {
+    Comment findCommentById(@Param("commentId") Long commentId);
 }

--- a/src/main/java/beyond/momentours/common/exception/ErrorCode.java
+++ b/src/main/java/beyond/momentours/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     USED_CODE_REQUEST(40010, HttpStatus.BAD_REQUEST, "사용된 QR코드입니다."),
     ALREADY_COUPLE_STATUS(40011, HttpStatus.BAD_REQUEST, "이미 커플인 회원입니다."),
     INVALID_RANDOM_QUESTION_STATUS(40012, HttpStatus.BAD_REQUEST, "답변이 완료된 상태가 아닙니다."),
+    INACTIVE_REPLY(40013, HttpStatus.BAD_REQUEST, "해당 대댓글은 삭제돼 있습니다."),
 
     // 401: 인증 실패 (Unauthorized)
     INVALID_HEADER_VALUE(40100, HttpStatus.UNAUTHORIZED, "올바르지 않은 헤더값입니다."), // 헤더 값이 잘못되었거나 누락된 경우
@@ -58,6 +59,7 @@ public enum ErrorCode {
     NOT_FOUND_QUES_ANSWER(40411, HttpStatus.NOT_FOUND, "답변이 존재하지 않습니다."),
     NOT_FOUND_PLAN(40412, HttpStatus.NOT_FOUND, "일정이 존재하지 않습니다."),
     NOT_FOUND_CODE(40413, HttpStatus.NOT_FOUND, "매칭코드가 존재하지 않습니다"),
+    NOT_FOUND_REPLY(40414, HttpStatus.NOT_FOUND, "해당 대댓글이 존재하지 않습니다"),
 
     // 429: 요청 과다 (Too Many Requests)
     TOO_MANY_REQUESTS(42900, HttpStatus.TOO_MANY_REQUESTS, "요청 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요."),

--- a/src/main/java/beyond/momentours/reply/command/application/controller/ReplyController.java
+++ b/src/main/java/beyond/momentours/reply/command/application/controller/ReplyController.java
@@ -1,0 +1,44 @@
+package beyond.momentours.reply.command.application.controller;
+
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.reply.command.application.dto.ReplyDTO;
+import beyond.momentours.reply.command.application.mapper.ReplyConvertor;
+import beyond.momentours.reply.command.application.service.ReplyService;
+import beyond.momentours.reply.command.domain.vo.request.RequestCreateReplyVO;
+import beyond.momentours.reply.command.domain.vo.response.ResponseCreateReplyVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("commandReplyController")
+@RequestMapping("api/reply")
+@Slf4j
+@RequiredArgsConstructor
+public class ReplyController {
+
+    private final ReplyService replyService;
+    private final ReplyConvertor replyConvertor;
+
+    @PostMapping
+    public ResponseEntity<?> createReply(@RequestBody RequestCreateReplyVO request) {
+        log.info("등록 요청된 대댓글 데이터 : {}", request);
+        try {
+            ReplyDTO replyDTO = replyConvertor.fromCreateVOToDTO(request);
+            ReplyDTO saveReplyDTO = replyService.createReply(replyDTO);
+            ResponseCreateReplyVO response = replyConvertor.fromDTOToCreateVO(saveReplyDTO);
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (CommonException e) {
+            log.error("대댓글 등록 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+}

--- a/src/main/java/beyond/momentours/reply/command/application/controller/ReplyController.java
+++ b/src/main/java/beyond/momentours/reply/command/application/controller/ReplyController.java
@@ -5,15 +5,14 @@ import beyond.momentours.reply.command.application.dto.ReplyDTO;
 import beyond.momentours.reply.command.application.mapper.ReplyConvertor;
 import beyond.momentours.reply.command.application.service.ReplyService;
 import beyond.momentours.reply.command.domain.vo.request.RequestCreateReplyVO;
+import beyond.momentours.reply.command.domain.vo.request.RequestUpdateReplyVO;
 import beyond.momentours.reply.command.domain.vo.response.ResponseCreateReplyVO;
+import beyond.momentours.reply.command.domain.vo.response.ResponseUpdateReplyVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController("commandReplyController")
 @RequestMapping("api/reply")
@@ -35,6 +34,43 @@ public class ReplyController {
             return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (CommonException e) {
             log.error("대댓글 등록 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @PatchMapping("/{replyId}")
+    public ResponseEntity<?> updateReply(@PathVariable Long replyId, @RequestBody RequestUpdateReplyVO request) {
+        log.info("수정 요청된 replyId: {}, 데이터: {}", replyId, request);
+        try {
+            ReplyDTO replyDTO = replyConvertor.fromUpdateVOToDTO(request);
+            replyDTO.setReplyId(replyId);
+
+            ReplyDTO updatedReply = replyService.updateReply(replyDTO);
+
+            ResponseUpdateReplyVO response = replyConvertor.fromDTOToUpdateVO(updatedReply);
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (CommonException e) {
+            log.error("대댓글 수정 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @PatchMapping("/deactivate/{replyId}")
+    public ResponseEntity<?> deleteReply(@PathVariable Long replyId) {
+        log.info("삭제 요청된 대댓글 ID : {}", replyId);
+        try {
+            ReplyDTO deletedReply = replyService.deleteReply(replyId);
+            log.info("삭제된 replyId : {}, 해당 대댓글의 상태 : {}", deletedReply.getReplyId(), deletedReply.getReplyStatus());
+            return ResponseEntity.status(HttpStatus.OK).body("대댓글이 성공적으로 삭제되었습니다.");
+        } catch (CommonException e) {
+            log.error("대댓글 삭제 오류: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         } catch (Exception e) {
             log.error("예상치 못한 오류", e);

--- a/src/main/java/beyond/momentours/reply/command/application/dto/ReplyDTO.java
+++ b/src/main/java/beyond/momentours/reply/command/application/dto/ReplyDTO.java
@@ -1,0 +1,21 @@
+package beyond.momentours.reply.command.application.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class ReplyDTO {
+    private Long replyId;
+    private String replyContent;
+    private Boolean replyStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long commentId;
+    private Long memberId;
+}

--- a/src/main/java/beyond/momentours/reply/command/application/mapper/ReplyConvertor.java
+++ b/src/main/java/beyond/momentours/reply/command/application/mapper/ReplyConvertor.java
@@ -1,0 +1,44 @@
+package beyond.momentours.reply.command.application.mapper;
+
+import beyond.momentours.reply.command.application.dto.ReplyDTO;
+import beyond.momentours.reply.command.domain.aggregate.entity.Reply;
+import beyond.momentours.reply.command.domain.vo.request.RequestCreateReplyVO;
+import beyond.momentours.reply.command.domain.vo.response.ResponseCreateReplyVO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReplyConvertor {
+    public ReplyDTO fromCreateVOToDTO(RequestCreateReplyVO request) {
+        return ReplyDTO.builder()
+                .replyContent(request.getReplyContent())
+                .commentId(request.getCommentId())
+                .build();
+    }
+
+    public ResponseCreateReplyVO fromDTOToCreateVO(ReplyDTO saveReplyDTO) {
+        return ResponseCreateReplyVO.builder()
+                .replyContent(saveReplyDTO.getReplyContent())
+                .commentId(saveReplyDTO.getCommentId())
+                .build();
+    }
+
+    public Reply fromDTOToEntity(ReplyDTO replyDTO) {
+        return Reply.builder()
+                .replyContent(replyDTO.getReplyContent())
+                .commentId(replyDTO.getCommentId())
+                .memberId(replyDTO.getMemberId())
+                .build();
+    }
+
+    public ReplyDTO fromEntityToDTO(Reply savedReply) {
+        return ReplyDTO.builder()
+                .replyId(savedReply.getReplyId())
+                .replyContent(savedReply.getReplyContent())
+                .replyStatus(savedReply.getReplyStatus())
+                .createdAt(savedReply.getCreatedAt())
+                .updatedAt(savedReply.getUpdatedAt())
+                .commentId(savedReply.getCommentId())
+                .memberId(savedReply.getMemberId())
+                .build();
+    }
+}

--- a/src/main/java/beyond/momentours/reply/command/application/mapper/ReplyConvertor.java
+++ b/src/main/java/beyond/momentours/reply/command/application/mapper/ReplyConvertor.java
@@ -3,7 +3,9 @@ package beyond.momentours.reply.command.application.mapper;
 import beyond.momentours.reply.command.application.dto.ReplyDTO;
 import beyond.momentours.reply.command.domain.aggregate.entity.Reply;
 import beyond.momentours.reply.command.domain.vo.request.RequestCreateReplyVO;
+import beyond.momentours.reply.command.domain.vo.request.RequestUpdateReplyVO;
 import beyond.momentours.reply.command.domain.vo.response.ResponseCreateReplyVO;
+import beyond.momentours.reply.command.domain.vo.response.ResponseUpdateReplyVO;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,6 +41,20 @@ public class ReplyConvertor {
                 .updatedAt(savedReply.getUpdatedAt())
                 .commentId(savedReply.getCommentId())
                 .memberId(savedReply.getMemberId())
+                .build();
+    }
+
+    public ReplyDTO fromUpdateVOToDTO(RequestUpdateReplyVO request) {
+        return ReplyDTO.builder()
+                .replyContent(request.getReplyContent())
+                .build();
+    }
+
+    public ResponseUpdateReplyVO fromDTOToUpdateVO(ReplyDTO updatedReply) {
+        return ResponseUpdateReplyVO.builder()
+                .replyId(updatedReply.getReplyId())
+                .replyContent(updatedReply.getReplyContent())
+                .updatedAt(updatedReply.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/beyond/momentours/reply/command/application/service/ReplyService.java
+++ b/src/main/java/beyond/momentours/reply/command/application/service/ReplyService.java
@@ -4,4 +4,8 @@ import beyond.momentours.reply.command.application.dto.ReplyDTO;
 
 public interface ReplyService {
     ReplyDTO createReply(ReplyDTO replyDTO);
+
+    ReplyDTO updateReply(ReplyDTO replyDTO);
+
+    ReplyDTO deleteReply(Long replyId);
 }

--- a/src/main/java/beyond/momentours/reply/command/application/service/ReplyService.java
+++ b/src/main/java/beyond/momentours/reply/command/application/service/ReplyService.java
@@ -1,0 +1,7 @@
+package beyond.momentours.reply.command.application.service;
+
+import beyond.momentours.reply.command.application.dto.ReplyDTO;
+
+public interface ReplyService {
+    ReplyDTO createReply(ReplyDTO replyDTO);
+}

--- a/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
+++ b/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
@@ -1,5 +1,9 @@
 package beyond.momentours.reply.command.application.service;
 
+import beyond.momentours.comment.command.domain.aggregate.entity.Comment;
+import beyond.momentours.comment.query.repository.CommentMapper;
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.common.exception.ErrorCode;
 import beyond.momentours.reply.command.application.dto.ReplyDTO;
 import beyond.momentours.reply.command.application.mapper.ReplyConvertor;
 import beyond.momentours.reply.command.domain.aggregate.entity.Reply;
@@ -16,12 +20,15 @@ public class ReplyServiceImpl implements ReplyService {
 
     private final ReplyRepository replyRepository;
     private final ReplyConvertor replyConvertor;
+    private final CommentMapper commentDAO;
     private final ReplyMapper replyDAO;
 
     @Override
     public ReplyDTO createReply(ReplyDTO replyDTO) {
+        validateCommentId(replyDTO.getCommentId());
+
 //        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
-        Long memberId = 0L;
+        Long memberId = 0L; // (임시로 0L 사용)
         replyDTO.setMemberId(memberId);
 
         Reply reply = replyConvertor.fromDTOToEntity(replyDTO);
@@ -31,5 +38,12 @@ public class ReplyServiceImpl implements ReplyService {
         Reply savedReply = replyRepository.save(reply);
 
         return replyConvertor.fromEntityToDTO(savedReply);
+    }
+
+    private void validateCommentId(Long commentId) {
+        Comment comment = commentDAO.findCommentById(commentId);
+        if (comment == null || !comment.getCommentStatus()) {
+            throw new CommonException(ErrorCode.NOT_FOUND_COMMENT);
+        }
     }
 }

--- a/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
+++ b/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
@@ -1,0 +1,35 @@
+package beyond.momentours.reply.command.application.service;
+
+import beyond.momentours.reply.command.application.dto.ReplyDTO;
+import beyond.momentours.reply.command.application.mapper.ReplyConvertor;
+import beyond.momentours.reply.command.domain.aggregate.entity.Reply;
+import beyond.momentours.reply.command.domain.repository.ReplyRepository;
+import beyond.momentours.reply.query.repository.ReplyMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("commandReplyService")
+@RequiredArgsConstructor
+public class ReplyServiceImpl implements ReplyService {
+
+    private final ReplyRepository replyRepository;
+    private final ReplyConvertor replyConvertor;
+    private final ReplyMapper replyDAO;
+
+    @Override
+    public ReplyDTO createReply(ReplyDTO replyDTO) {
+//        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
+        Long memberId = 0L;
+        replyDTO.setMemberId(memberId);
+
+        Reply reply = replyConvertor.fromDTOToEntity(replyDTO);
+        log.info("저장할 대댓글 데이터: {}", reply);
+
+        reply.create(reply);
+        Reply savedReply = replyRepository.save(reply);
+
+        return replyConvertor.fromEntityToDTO(savedReply);
+    }
+}

--- a/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
+++ b/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
@@ -40,10 +40,64 @@ public class ReplyServiceImpl implements ReplyService {
         return replyConvertor.fromEntityToDTO(savedReply);
     }
 
+    @Override
+    public ReplyDTO updateReply(ReplyDTO replyDTO) {
+//        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
+        Long memberId = 0L;
+
+        Reply existingReply = replyRepository.findById(replyDTO.getReplyId()).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_REPLY));
+        log.info("기존 Reply 데이터: {}", existingReply);
+
+        if (!existingReply.getReplyStatus()) {
+            log.error("비활성화된 대댓글: replyId: {}", replyDTO.getReplyId());
+            throw new CommonException(ErrorCode.INACTIVE_REPLY);
+        }
+
+        if (!existingReply.getMemberId().equals(memberId)) {
+            log.error("수정 권한 없음: 요청한 사용자 ID: {}, 대댓글 작성자 ID: {}", memberId, existingReply.getMemberId());
+            throw new CommonException(ErrorCode.ACCESS_DENIED);
+        }
+
+        updateReplyContent(replyDTO, existingReply);
+        log.info("수정 후 Reply 데이터: {}", existingReply);
+
+        replyRepository.save(existingReply);
+
+        return replyConvertor.fromEntityToDTO(existingReply);
+    }
+
+
+    @Override
+    public ReplyDTO deleteReply(Long replyId) {
+        Reply existingReply = replyRepository.findById(replyId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_REPLY));
+        log.info("삭제 요청된 Reply 데이터: {}", existingReply);
+
+//        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
+        Long memberId = 0L;
+
+        if (!existingReply.getMemberId().equals(memberId)) {
+            log.error("삭제 권한 없음: 요청한 사용자 ID: {}, 대댓글 작성자 ID: {}", memberId, existingReply.getMemberId());
+            throw new CommonException(ErrorCode.ACCESS_DENIED);
+        }
+
+        existingReply.updateStatus(false);
+        log.info("상태 변경 후 Reply 데이터: {}", existingReply);
+
+        replyRepository.save(existingReply);
+
+        return replyConvertor.fromEntityToDTO(existingReply);
+    }
+
     private void validateCommentId(Long commentId) {
         Comment comment = commentDAO.findCommentById(commentId);
         if (comment == null || !comment.getCommentStatus()) {
             throw new CommonException(ErrorCode.NOT_FOUND_COMMENT);
+        }
+    }
+
+    private void updateReplyContent(ReplyDTO replyDTO, Reply existingReply) {
+        if (replyDTO.getReplyContent() != null) {
+            existingReply.updateContent(replyDTO.getReplyContent());
         }
     }
 }

--- a/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
+++ b/src/main/java/beyond/momentours/reply/command/application/service/ReplyServiceImpl.java
@@ -42,6 +42,8 @@ public class ReplyServiceImpl implements ReplyService {
 
     @Override
     public ReplyDTO updateReply(ReplyDTO replyDTO) {
+        validateCommentId(replyDTO.getCommentId());
+
 //        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
         Long memberId = 0L;
 
@@ -71,6 +73,8 @@ public class ReplyServiceImpl implements ReplyService {
     public ReplyDTO deleteReply(Long replyId) {
         Reply existingReply = replyRepository.findById(replyId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_REPLY));
         log.info("삭제 요청된 Reply 데이터: {}", existingReply);
+
+        validateCommentId(existingReply.getCommentId());
 
 //        Long memberId = getLoggedInMemberId(); // 로그인한 사용자의 ID 가져오기
         Long memberId = 0L;

--- a/src/main/java/beyond/momentours/reply/command/domain/aggregate/entity/Reply.java
+++ b/src/main/java/beyond/momentours/reply/command/domain/aggregate/entity/Reply.java
@@ -1,0 +1,54 @@
+package beyond.momentours.reply.command.domain.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_reply")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reply_id")
+    private Long replyId;
+
+    @Column(name = "reply_content", nullable = false)
+    private String replyContent;
+
+    @Column(name = "reply_status", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
+    private Boolean replyStatus = true;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "comment_id", nullable = false)
+    private Long commentId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    public void create(Reply reply) {
+        reply.createdAt = LocalDateTime.now();
+        reply.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateContent(String commentContent) {
+        this.replyContent = commentContent;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateStatus(boolean status) {
+        this.replyStatus = status;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/beyond/momentours/reply/command/domain/repository/ReplyRepository.java
+++ b/src/main/java/beyond/momentours/reply/command/domain/repository/ReplyRepository.java
@@ -1,0 +1,9 @@
+package beyond.momentours.reply.command.domain.repository;
+
+import beyond.momentours.reply.command.domain.aggregate.entity.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+}

--- a/src/main/java/beyond/momentours/reply/command/domain/vo/request/RequestCreateReplyVO.java
+++ b/src/main/java/beyond/momentours/reply/command/domain/vo/request/RequestCreateReplyVO.java
@@ -1,0 +1,18 @@
+package beyond.momentours.reply.command.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RequestCreateReplyVO {
+
+    @JsonProperty("reply_content")
+    private String replyContent;
+
+    @JsonProperty("comment_id")
+    private Long commentId;
+}

--- a/src/main/java/beyond/momentours/reply/command/domain/vo/request/RequestUpdateReplyVO.java
+++ b/src/main/java/beyond/momentours/reply/command/domain/vo/request/RequestUpdateReplyVO.java
@@ -1,0 +1,15 @@
+package beyond.momentours.reply.command.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RequestUpdateReplyVO {
+
+    @JsonProperty("reply_content")
+    private String replyContent;
+}

--- a/src/main/java/beyond/momentours/reply/command/domain/vo/response/ResponseCreateReplyVO.java
+++ b/src/main/java/beyond/momentours/reply/command/domain/vo/response/ResponseCreateReplyVO.java
@@ -1,0 +1,19 @@
+package beyond.momentours.reply.command.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResponseCreateReplyVO {
+
+    @JsonProperty("reply_content")
+    private String replyContent;
+
+    @JsonProperty("comment_id")
+    private Long commentId;
+}

--- a/src/main/java/beyond/momentours/reply/command/domain/vo/response/ResponseUpdateReplyVO.java
+++ b/src/main/java/beyond/momentours/reply/command/domain/vo/response/ResponseUpdateReplyVO.java
@@ -1,0 +1,24 @@
+package beyond.momentours.reply.command.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResponseUpdateReplyVO {
+
+    @JsonProperty("reply_id")
+    private Long replyId;
+
+    @JsonProperty("reply_content")
+    private String replyContent;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/beyond/momentours/reply/query/repository/ReplyMapper.java
+++ b/src/main/java/beyond/momentours/reply/query/repository/ReplyMapper.java
@@ -1,0 +1,7 @@
+package beyond.momentours.reply.query.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ReplyMapper {
+}

--- a/src/main/resources/beyond/momentours/mapper/CommentMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/CommentMapper.xml
@@ -16,4 +16,19 @@
         <result property="coupleLogId" column="couple_log_id"/>
     </resultMap>
 
+    <select id="findCommentById" resultMap="commentResultMap">
+        SELECT
+               comment_id,
+               comment_content,
+               comment_type,
+               comment_status,
+               created_at,
+               updated_at,
+               member_id,
+               ques_ans_id,
+               couple_log_id
+          FROM tb_comment
+         WHERE comment_id = #{commentId}
+    </select>
+
 </mapper>

--- a/src/main/resources/beyond/momentours/mapper/reply/ReplyMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/reply/ReplyMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="beyond.momentours.reply.query.repository.ReplyMapper">
+    <resultMap id="replyResultMap" type="beyond.momentours.reply.command.domain.aggregate.entity.Reply">
+        <id property="replyId" column="reply_id"/>
+        <result property="replyContent" column="reply_content"/>
+        <result property="replyStatus" column="reply_status"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="commentId" column="comment_id"/>
+        <result property="memberId" column="member_id"/>
+    </resultMap>
+
+</mapper>


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
대댓글(reply) 등록, 수정 시 댓글이 삭제되지는 않았는지 검증하는 메서드를 추가해서 대댓글 등록 시에 확인한 뒤 등록되게끔 추가했습니다.
삭제는 soft delete로 구현했습니다.

  <br/>

## 🔧 앞으로의 과제

- 대댓글 등록 14시 50분 완료
- 대댓글 수정, 삭제 16시 완료
- 대댓글 조회 기능 추가 예정

  <br/>

close #40 