### PR TITLE
feat(#48): 데이트 코스 등록 기능 추가

### DIFF
--- a/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseController.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseController.java
@@ -1,0 +1,19 @@
+package beyond.momentours.date_course.command.application.controller;
+
+import beyond.momentours.date_course.command.application.mapper.DateCourseConverter;
+import beyond.momentours.date_course.command.application.service.DateCourseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("commandDateCourseController")
+@RequestMapping("api/course")
+@Slf4j
+@RequiredArgsConstructor
+public class DateCourseController {
+
+    private final DateCourseService dateCourseService;
+    private final DateCourseConverter dateCourseConverter;
+
+}

--- a/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseController.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseController.java
@@ -1,9 +1,19 @@
 package beyond.momentours.date_course.command.application.controller;
 
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.date_course.command.application.dto.DateCourseDTO;
 import beyond.momentours.date_course.command.application.mapper.DateCourseConverter;
 import beyond.momentours.date_course.command.application.service.DateCourseService;
+import beyond.momentours.date_course.command.domain.vo.request.RequestCreateDateCourseVO;
+import beyond.momentours.date_course.command.domain.vo.response.ResponseCreateDateCourseVO;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,4 +26,21 @@ public class DateCourseController {
     private final DateCourseService dateCourseService;
     private final DateCourseConverter dateCourseConverter;
 
+    @PostMapping
+    public ResponseEntity<?> createDateCourse(@RequestBody RequestCreateDateCourseVO request, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("등록 요청된 데이트 코스 데이터 : {}", request);
+        try {
+            DateCourseDTO dateCourseDTO = dateCourseConverter.fromCreateVOToDTO(request);
+            DateCourseDTO saveDateCourseDTO = dateCourseService.createDateCourse(dateCourseDTO, user);
+            ResponseCreateDateCourseVO response = dateCourseConverter.fromDTOToCreateVO(saveDateCourseDTO);
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (CommonException e) {
+            log.error("데이트 코스 등록 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/dto/DateCourseDTO.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/dto/DateCourseDTO.java
@@ -1,0 +1,28 @@
+package beyond.momentours.date_course.command.application.dto;
+
+import beyond.momentours.date_course.command.domain.aggregate.CourseType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class DateCourseDTO {
+    private Long courseId;
+    private String courseTitle;
+    private CourseType courseType;
+    private String courseMemo;
+    private Boolean courseDisclosure;
+    private Long courseLike;
+    private Long courseView;
+    private Boolean courseStatus;
+    private LocalDateTime courseStartDate;
+    private LocalDateTime courseEndDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long memberId;
+}

--- a/src/main/java/beyond/momentours/date_course/command/application/mapper/DateCourseConverter.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/mapper/DateCourseConverter.java
@@ -1,7 +1,68 @@
 package beyond.momentours.date_course.command.application.mapper;
 
+import beyond.momentours.date_course.command.application.dto.DateCourseDTO;
+import beyond.momentours.date_course.command.domain.aggregate.entity.DateCourse;
+import beyond.momentours.date_course.command.domain.vo.request.RequestCreateDateCourseVO;
+import beyond.momentours.date_course.command.domain.vo.response.ResponseCreateDateCourseVO;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DateCourseConverter {
+    public DateCourseDTO fromCreateVOToDTO(RequestCreateDateCourseVO request) {
+        return DateCourseDTO.builder()
+                .courseTitle(request.getCourseTitle())
+                .courseType(request.getCourseType())
+                .courseMemo(request.getCourseMemo())
+                .courseStartDate(request.getCourseStartDate())
+                .courseEndDate(request.getCourseEndDate())
+                .build();
+    }
+
+    public ResponseCreateDateCourseVO fromDTOToCreateVO(DateCourseDTO saveDateCourseDTO) {
+        return ResponseCreateDateCourseVO.builder()
+                .courseId(saveDateCourseDTO.getCourseId())
+                .courseTitle(saveDateCourseDTO.getCourseTitle())
+                .courseType(saveDateCourseDTO.getCourseType())
+                .courseMemo(saveDateCourseDTO.getCourseMemo())
+                .courseDisclosure(saveDateCourseDTO.getCourseDisclosure())
+                .courseLike(saveDateCourseDTO.getCourseLike())
+                .courseView(saveDateCourseDTO.getCourseView())
+                .courseStatus(saveDateCourseDTO.getCourseStatus())
+                .courseStartDate(saveDateCourseDTO.getCourseStartDate())
+                .courseEndDate(saveDateCourseDTO.getCourseEndDate())
+                .createdAt(saveDateCourseDTO.getCreatedAt())
+                .updatedAt(saveDateCourseDTO.getUpdatedAt())
+                .memberId(saveDateCourseDTO.getMemberId())
+                .build();
+    }
+
+    public DateCourse fromDTOToEntity(DateCourseDTO dateCourseDTO) {
+        return DateCourse.builder()
+                .courseTitle(dateCourseDTO.getCourseTitle())
+                .courseType(dateCourseDTO.getCourseType())
+                .courseMemo(dateCourseDTO.getCourseMemo())
+                .courseDisclosure(dateCourseDTO.getCourseDisclosure())
+                .courseStartDate(dateCourseDTO.getCourseStartDate())
+                .courseEndDate(dateCourseDTO.getCourseEndDate())
+                .memberId(dateCourseDTO.getMemberId())
+                .build();
+    }
+
+    public DateCourseDTO fromEntityToDTO(DateCourse savedCourse) {
+        return DateCourseDTO.builder()
+                .courseId(savedCourse.getCourseId())
+                .courseTitle(savedCourse.getCourseTitle())
+                .courseType(savedCourse.getCourseType())
+                .courseMemo(savedCourse.getCourseMemo())
+                .courseDisclosure(savedCourse.getCourseDisclosure())
+                .courseLike(savedCourse.getCourseLike())
+                .courseView(savedCourse.getCourseView())
+                .courseStatus(savedCourse.getCourseStatus())
+                .courseStartDate(savedCourse.getCourseStartDate())
+                .courseEndDate(savedCourse.getCourseEndDate())
+                .createdAt(savedCourse.getCreatedAt())
+                .updatedAt(savedCourse.getUpdatedAt())
+                .memberId(savedCourse.getMemberId())
+                .build();
+    }
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/mapper/DateCourseConverter.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/mapper/DateCourseConverter.java
@@ -1,0 +1,7 @@
+package beyond.momentours.date_course.command.application.mapper;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DateCourseConverter {
+}

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseService.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseService.java
@@ -1,0 +1,4 @@
+package beyond.momentours.date_course.command.application.service;
+
+public interface DateCourseService {
+}

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseService.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseService.java
@@ -1,4 +1,8 @@
 package beyond.momentours.date_course.command.application.service;
 
+import beyond.momentours.date_course.command.application.dto.DateCourseDTO;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+
 public interface DateCourseService {
+    DateCourseDTO createDateCourse(DateCourseDTO dateCourseDTO, CustomUserDetails user);
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseServiceImpl.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseServiceImpl.java
@@ -1,8 +1,12 @@
 package beyond.momentours.date_course.command.application.service;
 
+import beyond.momentours.date_course.command.application.dto.DateCourseDTO;
 import beyond.momentours.date_course.command.application.mapper.DateCourseConverter;
+import beyond.momentours.date_course.command.domain.aggregate.entity.DateCourse;
 import beyond.momentours.date_course.command.domain.repository.DateCourseRepository;
 import beyond.momentours.date_course.query.repository.DateCourseMapper;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import beyond.momentours.member.query.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,5 +19,18 @@ public class DateCourseServiceImpl implements DateCourseService {
     private final DateCourseRepository dateCourseRepository;
     private final DateCourseConverter dateCourseConverter;
     private final DateCourseMapper dateCourseDAO;
+    private final MemberService memberService;
 
+    @Override
+    public DateCourseDTO createDateCourse(DateCourseDTO dateCourseDTO, CustomUserDetails user) {
+        Long memberId = memberService.findByMemberId(user.getUsername());
+        dateCourseDTO.setMemberId(memberId);
+
+        DateCourse dateCourse = dateCourseConverter.fromDTOToEntity(dateCourseDTO);
+        log.info("저장할 데이트 코스 : {}", dateCourse);
+
+        DateCourse savedCourse = dateCourseRepository.save(dateCourse);
+
+        return dateCourseConverter.fromEntityToDTO(savedCourse);
+    }
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseServiceImpl.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseServiceImpl.java
@@ -1,0 +1,19 @@
+package beyond.momentours.date_course.command.application.service;
+
+import beyond.momentours.date_course.command.application.mapper.DateCourseConverter;
+import beyond.momentours.date_course.command.domain.repository.DateCourseRepository;
+import beyond.momentours.date_course.query.repository.DateCourseMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("commandDateCourseService")
+@RequiredArgsConstructor
+public class DateCourseServiceImpl implements DateCourseService {
+
+    private final DateCourseRepository dateCourseRepository;
+    private final DateCourseConverter dateCourseConverter;
+    private final DateCourseMapper dateCourseDAO;
+
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/CourseType.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/CourseType.java
@@ -1,0 +1,5 @@
+package beyond.momentours.date_course.command.domain.aggregate;
+
+public enum CourseType {
+
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/CourseType.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/CourseType.java
@@ -1,5 +1,17 @@
 package beyond.momentours.date_course.command.domain.aggregate;
 
-public enum CourseType {
+import com.fasterxml.jackson.annotation.JsonValue;
 
+public enum CourseType {
+    DATE("DATE"),
+    TRIP("TRIP");
+
+    private final String courseType;
+
+    CourseType(String courseType) { this.courseType = courseType; }
+
+    @JsonValue
+    public String getType() {
+        return courseType;
+    }
 }

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
@@ -30,8 +30,8 @@ public class DateCourse {
     @Column(name = "course_memo")
     private String courseMemo;
 
-    @Column(name = "course_disclosure", nullable = false)
-    private Boolean courseDisclosure;
+    @Column(name = "course_disclosure", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
+    private Boolean courseDisclosure = true;
 
     @Column(name = "course_like")
     private Long courseLike;
@@ -56,4 +56,12 @@ public class DateCourse {
 
     @Column(name = "member_id", nullable = false)
     private Long memberId;
+
+    @PrePersist
+    private void onCreate() {
+        this.courseLike = 0L;
+        this.courseView = 0L;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
@@ -30,8 +30,8 @@ public class DateCourse {
     @Column(name = "course_memo")
     private String courseMemo;
 
-    @Column(name = "course_disclosure", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
-    private Boolean courseDisclosure = true;
+    @Column(name = "course_disclosure", nullable = false)
+    private Boolean courseDisclosure;
 
     @Column(name = "course_like")
     private Long courseLike;

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
@@ -1,0 +1,59 @@
+package beyond.momentours.date_course.command.domain.aggregate.entity;
+
+import beyond.momentours.date_course.command.domain.aggregate.CourseType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_date_course")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class DateCourse {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_id")
+    private Long courseId;
+
+    @Column(name = "course_title", nullable = false)
+    private String courseTitle;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "course_type", nullable = false)
+    private CourseType courseType;
+
+    @Column(name = "course_memo")
+    private String courseMemo;
+
+    @Column(name = "course_disclosure", nullable = false)
+    private Boolean courseDisclosure;
+
+    @Column(name = "course_like")
+    private Long courseLike;
+
+    @Column(name = "course_view")
+    private Long courseView;
+
+    @Column(name = "course_status", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
+    private Boolean courseStatus = true;
+
+    @Column(name = "course_start_date", nullable = false)
+    private LocalDateTime courseStartDate;
+
+    @Column(name = "course_end_date", nullable = false)
+    private LocalDateTime courseEndDate;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/repository/DateCourseRepository.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/repository/DateCourseRepository.java
@@ -1,0 +1,9 @@
+package beyond.momentours.date_course.command.domain.repository;
+
+import beyond.momentours.date_course.command.domain.aggregate.entity.DateCourse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DateCourseRepository extends JpaRepository<DateCourse, Long> {
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestCreateDateCourseVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestCreateDateCourseVO.java
@@ -14,7 +14,6 @@ public class RequestCreateDateCourseVO {
     private String courseTitle;
     private CourseType courseType;
     private String courseMemo;
-    private Boolean courseDisclosure;
     private LocalDateTime courseStartDate;
     private LocalDateTime courseEndDate;
 }

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestCreateDateCourseVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestCreateDateCourseVO.java
@@ -1,0 +1,20 @@
+package beyond.momentours.date_course.command.domain.vo.request;
+
+import beyond.momentours.date_course.command.domain.aggregate.CourseType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RequestCreateDateCourseVO {
+    private String courseTitle;
+    private CourseType courseType;
+    private String courseMemo;
+    private Boolean courseDisclosure;
+    private LocalDateTime courseStartDate;
+    private LocalDateTime courseEndDate;
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/response/ResponseCreateDateCourseVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/response/ResponseCreateDateCourseVO.java
@@ -1,0 +1,27 @@
+package beyond.momentours.date_course.command.domain.vo.response;
+
+import beyond.momentours.date_course.command.domain.aggregate.CourseType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class ResponseCreateDateCourseVO {
+    private Long courseId;
+    private String courseTitle;
+    private CourseType courseType;
+    private String courseMemo;
+    private Boolean courseDisclosure;
+    private Long courseLike;
+    private Long courseView;
+    private Boolean courseStatus;
+    private LocalDateTime courseStartDate;
+    private LocalDateTime courseEndDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long memberId;
+}

--- a/src/main/java/beyond/momentours/date_course/query/repository/DateCourseMapper.java
+++ b/src/main/java/beyond/momentours/date_course/query/repository/DateCourseMapper.java
@@ -1,0 +1,7 @@
+package beyond.momentours.date_course.query.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DateCourseMapper {
+}


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
데이트 코스 등록을 추가했고 `@AuthenticationPrincipal CustomUserDetails` 을 활용해 로그인 한 유저의 정보를 받고 그걸 이용해 memberId를 dto에 setter 로 넣어서 엔터티로 변환했고 등록할 때 사용했습니다.

  <br/>

## 🔧 앞으로의 과제

- 나머지 CRUD, 맡은 엔터티 컨트롤러에 로그인 한 유저 정보 파라미터 추가하기

  <br/>

close #48 