### PR TITLE
feat( #71 ): 데이트 코스 즐겨찾기 생성, 삭제, 조회 기능 추가

### DIFF
--- a/src/main/java/beyond/momentours/common/exception/ErrorCode.java
+++ b/src/main/java/beyond/momentours/common/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     NOT_FOUND_PLAN(40412, HttpStatus.NOT_FOUND, "일정이 존재하지 않습니다."),
     NOT_FOUND_CODE(40413, HttpStatus.NOT_FOUND, "매칭코드가 존재하지 않습니다"),
     NOT_FOUND_REPLY(40414, HttpStatus.NOT_FOUND, "해당 대댓글이 존재하지 않습니다"),
+    NOT_FOUND_DATE_COURSE_SCRAP_FOLDER(40415, HttpStatus.NOT_FOUND, "해당 데이트 코스 즐겨찾기 폴더가 존재하지 않습니다"),
 
     // 429: 요청 과다 (Too Many Requests)
     TOO_MANY_REQUESTS(42900, HttpStatus.TOO_MANY_REQUESTS, "요청 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요."),

--- a/src/main/java/beyond/momentours/config/RedisConfig.java
+++ b/src/main/java/beyond/momentours/config/RedisConfig.java
@@ -4,6 +4,7 @@ import beyond.momentours.couple.command.domain.aggregate.entity.MatchingCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -24,6 +25,16 @@ public class RedisConfig {
         // Redis 연결 설정
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
         return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> customStringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
     }
 
     @Bean

--- a/src/main/java/beyond/momentours/config/SchedulerConfig.java
+++ b/src/main/java/beyond/momentours/config/SchedulerConfig.java
@@ -2,6 +2,7 @@ package beyond.momentours.config;
 
 import beyond.momentours.date_course.query.repository.DateCourseMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,7 +19,7 @@ public class SchedulerConfig {
     private final RedisTemplate<String, String> redisTemplate;
     private final DateCourseMapper dateCourseDAO;
 
-    public SchedulerConfig(RedisTemplate<String, String> redisTemplate, DateCourseMapper dateCourseDAO) {
+    public SchedulerConfig(@Qualifier("customStringRedisTemplate") RedisTemplate<String, String> redisTemplate, DateCourseMapper dateCourseDAO) {
         this.redisTemplate = redisTemplate;
         this.dateCourseDAO = dateCourseDAO;
     }

--- a/src/main/java/beyond/momentours/course_scrap/command/domain/aggregate/entity/CourseScrap.java
+++ b/src/main/java/beyond/momentours/course_scrap/command/domain/aggregate/entity/CourseScrap.java
@@ -1,0 +1,34 @@
+package beyond.momentours.course_scrap.command.domain.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_course_scrap")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CourseScrap {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_scrap_id")
+    private Long courseScrapId;
+
+    @Column(name = "course_scrap_folder_id", nullable = false)
+    private Long courseScrapFolderId;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/controller/CourseScrapFolderController.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/controller/CourseScrapFolderController.java
@@ -1,0 +1,55 @@
+package beyond.momentours.course_scrap_folder.command.application.controller;
+
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrapFolderDTO;
+import beyond.momentours.course_scrap_folder.command.application.mapper.CourseScrapFolderConverter;
+import beyond.momentours.course_scrap_folder.command.application.service.CourseScrapFolderService;
+import beyond.momentours.course_scrap_folder.command.domain.vo.request.RequestCreateCourseScrapFolderVO;
+import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCreateCourseScrapFolderVO;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController("commandDateCourseScrapFolderController")
+@RequestMapping("api/course-scrap-folder")
+@Slf4j
+@RequiredArgsConstructor
+public class CourseScrapFolderController {
+
+    private final CourseScrapFolderService courseScrapFolderService;
+    private final CourseScrapFolderConverter courseScrapFolderConverter;
+
+    @PostMapping
+    public ResponseEntity<?> createCourseScrapFolder(@RequestBody RequestCreateCourseScrapFolderVO request, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("데이트 코스 즐겨찾기 폴더 생성 요청: {}", request);
+        try {
+            CourseScrapFolderDTO folderDTO = courseScrapFolderConverter.fromCreateVOToDTO(request);
+            CourseScrapFolderDTO savedFolderDTO = courseScrapFolderService.createFolder(folderDTO, user);
+            ResponseCreateCourseScrapFolderVO response = courseScrapFolderConverter.fromDTOToCreateVO(savedFolderDTO);
+
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (Exception e) {
+            log.error("폴더 생성 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("폴더 생성 중 오류가 발생했습니다.");
+        }
+    }
+
+    @DeleteMapping("/{folderId}")
+    public ResponseEntity<?> deleteCourseScrapFolder(@PathVariable Long folderId, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("폴더 삭제 요청: folderId={}, user={}", folderId, user.getMemberId());
+        try {
+            courseScrapFolderService.deleteFolder(folderId, user);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } catch (CommonException e) {
+            log.error("폴더 삭제 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("폴더 삭제 중 예상치 못한 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("폴더 삭제 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/controller/CourseScrapFolderController.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/controller/CourseScrapFolderController.java
@@ -5,6 +5,7 @@ import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrap
 import beyond.momentours.course_scrap_folder.command.application.mapper.CourseScrapFolderConverter;
 import beyond.momentours.course_scrap_folder.command.application.service.CourseScrapFolderService;
 import beyond.momentours.course_scrap_folder.command.domain.vo.request.RequestCreateCourseScrapFolderVO;
+import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCourseScrapFolderVO;
 import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCreateCourseScrapFolderVO;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController("commandDateCourseScrapFolderController")
 @RequestMapping("api/course-scrap-folder")
@@ -50,6 +53,18 @@ public class CourseScrapFolderController {
         } catch (Exception e) {
             log.error("폴더 삭제 중 예상치 못한 오류 발생", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("폴더 삭제 중 오류가 발생했습니다.");
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getCourseScrapFolders(@AuthenticationPrincipal CustomUserDetails user) {
+        log.info("사용자가 등록한 즐겨찾기 폴더 조회 요청: userId={}", user.getMemberId());
+        try {
+            List<ResponseCourseScrapFolderVO> folders = courseScrapFolderService.getFoldersByMemberId(user.getMemberId());
+            return ResponseEntity.status(HttpStatus.OK).body(folders);
+        } catch (Exception e) {
+            log.error("즐겨찾기 폴더 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("즐겨찾기 폴더 조회 중 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/dto/CourseScrapFolderDTO.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/dto/CourseScrapFolderDTO.java
@@ -1,0 +1,19 @@
+package beyond.momentours.course_scrap_folder.command.application.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CourseScrapFolderDTO {
+    private Long courseScrapFolderId;
+    private String folderName;
+    private Long memberId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/mapper/CourseScrapFolderConverter.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/mapper/CourseScrapFolderConverter.java
@@ -1,0 +1,43 @@
+package beyond.momentours.course_scrap_folder.command.application.mapper;
+
+import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrapFolderDTO;
+import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
+import beyond.momentours.course_scrap_folder.command.domain.vo.request.RequestCreateCourseScrapFolderVO;
+import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCreateCourseScrapFolderVO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CourseScrapFolderConverter {
+    public CourseScrapFolderDTO fromCreateVOToDTO(RequestCreateCourseScrapFolderVO request) {
+        return CourseScrapFolderDTO.builder()
+                .folderName(request.getFolderName())
+                .build();
+    }
+
+    public ResponseCreateCourseScrapFolderVO fromDTOToCreateVO(CourseScrapFolderDTO folderDTO) {
+        return ResponseCreateCourseScrapFolderVO.builder()
+                .folderId(folderDTO.getCourseScrapFolderId())
+                .folderName(folderDTO.getFolderName())
+                .memberId(folderDTO.getMemberId())
+                .createdAt(folderDTO.getCreatedAt())
+                .updatedAt(folderDTO.getUpdatedAt())
+                .build();
+    }
+
+    public CourseScrapFolder fromDTOToEntity(CourseScrapFolderDTO folderDTO) {
+        return CourseScrapFolder.builder()
+                .folderName(folderDTO.getFolderName())
+                .memberId(folderDTO.getMemberId())
+                .build();
+    }
+
+    public CourseScrapFolderDTO fromEntityToDTO(CourseScrapFolder folder) {
+        return CourseScrapFolderDTO.builder()
+                .courseScrapFolderId(folder.getCourseScrapFolderId())
+                .folderName(folder.getFolderName())
+                .memberId(folder.getMemberId())
+                .createdAt(folder.getCreatedAt())
+                .updatedAt(folder.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/mapper/CourseScrapFolderConverter.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/mapper/CourseScrapFolderConverter.java
@@ -3,6 +3,7 @@ package beyond.momentours.course_scrap_folder.command.application.mapper;
 import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrapFolderDTO;
 import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
 import beyond.momentours.course_scrap_folder.command.domain.vo.request.RequestCreateCourseScrapFolderVO;
+import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCourseScrapFolderVO;
 import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCreateCourseScrapFolderVO;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +37,15 @@ public class CourseScrapFolderConverter {
                 .courseScrapFolderId(folder.getCourseScrapFolderId())
                 .folderName(folder.getFolderName())
                 .memberId(folder.getMemberId())
+                .createdAt(folder.getCreatedAt())
+                .updatedAt(folder.getUpdatedAt())
+                .build();
+    }
+
+    public ResponseCourseScrapFolderVO fromEntityToResponseVO(CourseScrapFolder folder) {
+        return ResponseCourseScrapFolderVO.builder()
+                .folderId(folder.getCourseScrapFolderId())
+                .folderName(folder.getFolderName())
                 .createdAt(folder.getCreatedAt())
                 .updatedAt(folder.getUpdatedAt())
                 .build();

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderService.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderService.java
@@ -1,0 +1,10 @@
+package beyond.momentours.course_scrap_folder.command.application.service;
+
+import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrapFolderDTO;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+
+public interface CourseScrapFolderService {
+    CourseScrapFolderDTO createFolder(CourseScrapFolderDTO folderDTO, CustomUserDetails user);
+
+    void deleteFolder(Long folderId, CustomUserDetails user);
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderService.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderService.java
@@ -1,10 +1,15 @@
 package beyond.momentours.course_scrap_folder.command.application.service;
 
 import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrapFolderDTO;
+import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCourseScrapFolderVO;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
+
+import java.util.List;
 
 public interface CourseScrapFolderService {
     CourseScrapFolderDTO createFolder(CourseScrapFolderDTO folderDTO, CustomUserDetails user);
 
     void deleteFolder(Long folderId, CustomUserDetails user);
+
+    List<ResponseCourseScrapFolderVO> getFoldersByMemberId(Long memberId);
 }

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderServiceImpl.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderServiceImpl.java
@@ -1,0 +1,52 @@
+package beyond.momentours.course_scrap_folder.command.application.service;
+
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrapFolderDTO;
+import beyond.momentours.course_scrap_folder.command.application.mapper.CourseScrapFolderConverter;
+import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
+import beyond.momentours.course_scrap_folder.command.domain.repository.CourseScrapFolderRepository;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("commandDateCourseScrapFolderService")
+@RequiredArgsConstructor
+public class CourseScrapFolderServiceImpl implements CourseScrapFolderService {
+
+    private final CourseScrapFolderRepository courseScrapFolderRepository;
+    private final CourseScrapFolderConverter courseScrapFolderConverter;
+
+    @Override
+    @Transactional
+    public CourseScrapFolderDTO createFolder(CourseScrapFolderDTO folderDTO, CustomUserDetails user) {
+        try {
+            Long memberId = user.getMemberId();
+            folderDTO.setMemberId(memberId);
+
+            CourseScrapFolder folderEntity = courseScrapFolderConverter.fromDTOToEntity(folderDTO);
+            log.info("저장할 폴더 데이터: {}", folderEntity);
+            CourseScrapFolder savedFolder = courseScrapFolderRepository.save(folderEntity);
+            log.info("폴더 저장 성공: {}", savedFolder);
+
+            return courseScrapFolderConverter.fromEntityToDTO(savedFolder);
+        } catch (Exception e) {
+            log.error("폴더 저장 중 오류 발생", e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteFolder(Long folderId, CustomUserDetails user) {
+        CourseScrapFolder folder = courseScrapFolderRepository.findById(folderId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_DATE_COURSE_SCRAP_FOLDER));
+
+        if (!folder.getMemberId().equals(user.getMemberId())) throw new CommonException(ErrorCode.UNAUTHORIZED_ACCESS);
+
+        courseScrapFolderRepository.deleteById(folderId);
+        log.info("폴더 삭제 완료: folderId={}", folderId);
+    }
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderServiceImpl.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderServiceImpl.java
@@ -7,6 +7,7 @@ import beyond.momentours.course_scrap_folder.command.application.mapper.CourseSc
 import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
 import beyond.momentours.course_scrap_folder.command.domain.repository.CourseScrapFolderRepository;
 import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCourseScrapFolderVO;
+import beyond.momentours.course_scrap_folder.query.repository.CourseScrapFolderMapper;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class CourseScrapFolderServiceImpl implements CourseScrapFolderService {
 
     private final CourseScrapFolderRepository courseScrapFolderRepository;
     private final CourseScrapFolderConverter courseScrapFolderConverter;
+    private final CourseScrapFolderMapper courseScrapFolderDAO;
 
     @Override
     @Transactional
@@ -55,7 +57,7 @@ public class CourseScrapFolderServiceImpl implements CourseScrapFolderService {
 
     @Transactional
     public List<ResponseCourseScrapFolderVO> getFoldersByMemberId(Long memberId) {
-        List<CourseScrapFolder> folders = courseScrapFolderRepository.findByMemberId(memberId);
+        List<CourseScrapFolder> folders = courseScrapFolderDAO.findByMemberId(memberId);
         return folders.stream()
                 .map(courseScrapFolderConverter::fromEntityToResponseVO)
                 .toList();

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderServiceImpl.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/application/service/CourseScrapFolderServiceImpl.java
@@ -6,11 +6,14 @@ import beyond.momentours.course_scrap_folder.command.application.dto.CourseScrap
 import beyond.momentours.course_scrap_folder.command.application.mapper.CourseScrapFolderConverter;
 import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
 import beyond.momentours.course_scrap_folder.command.domain.repository.CourseScrapFolderRepository;
+import beyond.momentours.course_scrap_folder.command.domain.vo.response.ResponseCourseScrapFolderVO;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service("commandDateCourseScrapFolderService")
@@ -48,5 +51,13 @@ public class CourseScrapFolderServiceImpl implements CourseScrapFolderService {
 
         courseScrapFolderRepository.deleteById(folderId);
         log.info("폴더 삭제 완료: folderId={}", folderId);
+    }
+
+    @Transactional
+    public List<ResponseCourseScrapFolderVO> getFoldersByMemberId(Long memberId) {
+        List<CourseScrapFolder> folders = courseScrapFolderRepository.findByMemberId(memberId);
+        return folders.stream()
+                .map(courseScrapFolderConverter::fromEntityToResponseVO)
+                .toList();
     }
 }

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/domain/aggregate/entity/CourseScrapFolder.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/domain/aggregate/entity/CourseScrapFolder.java
@@ -1,0 +1,43 @@
+package beyond.momentours.course_scrap_folder.command.domain.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_course_scrap_folder")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CourseScrapFolder {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_scrap_folder_id")
+    private Long courseScrapFolderId;
+
+    @Column(name = "folder_name", nullable = false)
+    private String folderName;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    private void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/domain/repository/CourseScrapFolderRepository.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/domain/repository/CourseScrapFolderRepository.java
@@ -1,0 +1,9 @@
+package beyond.momentours.course_scrap_folder.command.domain.repository;
+
+import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseScrapFolderRepository extends JpaRepository<CourseScrapFolder, Long> {
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/domain/vo/request/RequestCreateCourseScrapFolderVO.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/domain/vo/request/RequestCreateCourseScrapFolderVO.java
@@ -1,0 +1,13 @@
+package beyond.momentours.course_scrap_folder.command.domain.vo.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class RequestCreateCourseScrapFolderVO {
+    private String folderName;
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/domain/vo/response/ResponseCourseScrapFolderVO.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/domain/vo/response/ResponseCourseScrapFolderVO.java
@@ -1,0 +1,17 @@
+package beyond.momentours.course_scrap_folder.command.domain.vo.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class ResponseCourseScrapFolderVO {
+    private Long folderId;
+    private String folderName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/command/domain/vo/response/ResponseCreateCourseScrapFolderVO.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/command/domain/vo/response/ResponseCreateCourseScrapFolderVO.java
@@ -1,0 +1,19 @@
+package beyond.momentours.course_scrap_folder.command.domain.vo.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class ResponseCreateCourseScrapFolderVO {
+    private Long folderId;
+    private String folderName;
+    private Long memberId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/beyond/momentours/course_scrap_folder/query/repository/CourseScrapFolderMapper.java
+++ b/src/main/java/beyond/momentours/course_scrap_folder/query/repository/CourseScrapFolderMapper.java
@@ -1,0 +1,12 @@
+package beyond.momentours.course_scrap_folder.query.repository;
+
+import beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CourseScrapFolderMapper {
+    List<CourseScrapFolder> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
@@ -48,6 +48,9 @@ public class DateCourse {
     @Column(name = "course_end_date", nullable = false)
     private LocalDateTime courseEndDate;
 
+    @Column(name = "course_certification", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean courseCertification = false;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/resources/beyond/momentours/mapper/course_scrap_folder/CourseScrapFolderMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/course_scrap_folder/CourseScrapFolderMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="beyond.momentours.course_scrap_folder.query.repository.CourseScrapFolderMapper">
+
+    <resultMap id="courseScrapFolderResultMap" type="beyond.momentours.course_scrap_folder.command.domain.aggregate.entity.CourseScrapFolder">
+        <id property="courseScrapFolderId" column="course_scrap_folder_id"/>
+        <result property="folderName" column="folder_name"/>
+        <result property="memberId" column="member_id"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <select id="findByMemberId" resultMap="courseScrapFolderResultMap">
+        SELECT course_scrap_folder_id, folder_name, member_id, created_at, updated_at
+          FROM tb_course_scrap_folder
+         WHERE member_id = #{memberId}
+    </select>
+</mapper>


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
데이트 코스 즐겨찾기 생성 기능을 추가했고, 삭제 기능은 soft delete로 할 이유가 딱히 없다고 느껴 hard delete로 했습니다.
그리고 조회 기능은 본인의 즐겨찾기를 조회하게끔 구현했습니다. 

  <br/>

## 🔧 앞으로의 과제

- 즐겨찾기 폴더에 즐겨찾기 하는 데이트코스 CRUD 추가

  <br/>

close #71 