### PR TITLE
feat(#90): 데이트 코스에서 추억을 통해 증명하는 것 + 일정 등록하는 기능 추가

### DIFF
--- a/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseCommandController.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseCommandController.java
@@ -98,16 +98,14 @@ public class DateCourseCommandController {
         }
     }
 
-    @Operation(description = "데이트 코스에서 특정 코스 일정 등록할 때 null이었던 시작일, 종료일 수정")
-    @PatchMapping("/{courseId}/schedule")
+    @Operation(description = "데이트 코스에서 특정 코스 일정 등록할 때 null이었던 시작일, 종료일 수정, 타입도 설정")
+    @PostMapping("/{courseId}/schedule")
     public ResponseEntity<?> updateCourseSchedule(@PathVariable Long courseId, @RequestBody @Valid RequestUpdateDateCourseScheduleVO request, @AuthenticationPrincipal CustomUserDetails user) {
-        log.info("데이트 코스 일정 업데이트 요청: courseId={}, userId={}, start={}, end={}",
-                courseId, user.getMemberId(), request.getCourseStartDate(), request.getCourseEndDate());
+        log.info("데이트 코스 일정 업데이트 요청: courseId={}, userId={}, start={}, end={}, planType={}", courseId, user.getMemberId(), request.getCourseStartDate(), request.getCourseEndDate(), request.getPlanType());
         try {
             DateCourseDTO dateCourseDTO = dateCourseConverter.fromUpdateScheduleVOToDTO(request, courseId);
-            DateCourseDTO updatedCourseDTO = dateCourseCommandService.updateCourseSchedule(dateCourseDTO, user);
+            DateCourseDTO updatedCourseDTO = dateCourseCommandService.updateCourseSchedule(dateCourseDTO, user, request.getPlanType());
             ResponseUpdateDateCourseVO response = dateCourseConverter.fromDTOToUpdateVO(updatedCourseDTO);
-
             return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (CommonException e) {
             log.error("데이트 코스 일정 업데이트 오류: {}", e.getMessage());
@@ -117,5 +115,4 @@ public class DateCourseCommandController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
         }
     }
-
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseCommandController.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/controller/DateCourseCommandController.java
@@ -5,10 +5,13 @@ import beyond.momentours.date_course.command.application.dto.DateCourseDTO;
 import beyond.momentours.date_course.command.application.mapper.DateCourseConverter;
 import beyond.momentours.date_course.command.application.service.DateCourseCommandService;
 import beyond.momentours.date_course.command.domain.vo.request.RequestCreateDateCourseVO;
+import beyond.momentours.date_course.command.domain.vo.request.RequestUpdateDateCourseScheduleVO;
 import beyond.momentours.date_course.command.domain.vo.request.RequestUpdateDateCourseVO;
 import beyond.momentours.date_course.command.domain.vo.response.ResponseCreateDateCourseVO;
 import beyond.momentours.date_course.command.domain.vo.response.ResponseUpdateDateCourseVO;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -25,6 +28,7 @@ public class DateCourseCommandController {
     private final DateCourseCommandService dateCourseCommandService;
     private final DateCourseConverter dateCourseConverter;
 
+    @Operation(description = "데이트 코스 등록 시")
     @PostMapping
     public ResponseEntity<?> createDateCourse(@RequestBody RequestCreateDateCourseVO request, @AuthenticationPrincipal CustomUserDetails user) {
         log.info("등록 요청된 데이트 코스 데이터 : {}", request);
@@ -43,6 +47,7 @@ public class DateCourseCommandController {
         }
     }
 
+    @Operation(description = "데이트 코스 수정 시 (폴더 이동 X, 코스의 정보 수정 O)")
     @PatchMapping("/{courseId}")
     public ResponseEntity<?> updateDateCourse(@PathVariable Long courseId, @RequestBody RequestUpdateDateCourseVO request, @AuthenticationPrincipal CustomUserDetails user) {
         log.info("수정 요청된 데이트 코스 데이터 : {}", request);
@@ -61,6 +66,7 @@ public class DateCourseCommandController {
         }
     }
 
+    @Operation(description = "데이트 코스 삭제 시 (soft delete)")
     @PatchMapping("/deactivate/{courseId}")
     public ResponseEntity<?> deleteDateCourse(@PathVariable Long courseId, @AuthenticationPrincipal CustomUserDetails user) {
         log.info("데이트 코스 Soft Delete 요청: courseId={}, userId={}", courseId, user.getMemberId());
@@ -75,4 +81,41 @@ public class DateCourseCommandController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
         }
     }
+
+    @Operation(description = "본인이 작성한 데이트 코스 증명 시 certification 변경")
+    @PatchMapping("/certification/{courseId}")
+    public ResponseEntity<?> certificationCourse(@PathVariable Long courseId, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("데이트 코스 인증 요청: courseId={}, userId={}", courseId, user.getMemberId());
+        try {
+            dateCourseCommandService.certifyDateCourse(courseId, user);
+            return ResponseEntity.status(HttpStatus.OK).body("데이트 코스가 인증되었습니다.");
+        } catch (CommonException e) {
+            log.error("데이트 코스 인증 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @Operation(description = "데이트 코스에서 특정 코스 일정 등록할 때 null이었던 시작일, 종료일 수정")
+    @PatchMapping("/{courseId}/schedule")
+    public ResponseEntity<?> updateCourseSchedule(@PathVariable Long courseId, @RequestBody @Valid RequestUpdateDateCourseScheduleVO request, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("데이트 코스 일정 업데이트 요청: courseId={}, userId={}, start={}, end={}",
+                courseId, user.getMemberId(), request.getCourseStartDate(), request.getCourseEndDate());
+        try {
+            DateCourseDTO dateCourseDTO = dateCourseConverter.fromUpdateScheduleVOToDTO(request, courseId);
+            DateCourseDTO updatedCourseDTO = dateCourseCommandService.updateCourseSchedule(dateCourseDTO, user);
+            ResponseUpdateDateCourseVO response = dateCourseConverter.fromDTOToUpdateVO(updatedCourseDTO);
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (CommonException e) {
+            log.error("데이트 코스 일정 업데이트 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/mapper/DateCourseConverter.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/mapper/DateCourseConverter.java
@@ -3,6 +3,7 @@ package beyond.momentours.date_course.command.application.mapper;
 import beyond.momentours.date_course.command.application.dto.DateCourseDTO;
 import beyond.momentours.date_course.command.domain.aggregate.entity.DateCourse;
 import beyond.momentours.date_course.command.domain.vo.request.RequestCreateDateCourseVO;
+import beyond.momentours.date_course.command.domain.vo.request.RequestUpdateDateCourseScheduleVO;
 import beyond.momentours.date_course.command.domain.vo.request.RequestUpdateDateCourseVO;
 import beyond.momentours.date_course.command.domain.vo.response.ResponseCreateDateCourseVO;
 import beyond.momentours.date_course.command.domain.vo.response.ResponseDateCourseDetailVO;
@@ -20,8 +21,6 @@ public class DateCourseConverter {
                 .courseTitle(request.getCourseTitle())
                 .courseType(request.getCourseType())
                 .courseDisclosure(request.getCourseDisclosure())
-                .courseStartDate(request.getCourseStartDate())
-                .courseEndDate(request.getCourseEndDate())
                 .folderId(request.getFolderId())
                 .build();
     }
@@ -80,8 +79,6 @@ public class DateCourseConverter {
                 .courseTitle(request.getCourseTitle())
                 .courseType(request.getCourseType())
                 .courseDisclosure(request.getCourseDisclosure())
-                .courseStartDate(request.getCourseStartDate())
-                .courseEndDate(request.getCourseEndDate())
                 .build();
     }
 
@@ -127,6 +124,14 @@ public class DateCourseConverter {
                 .createdAt(dateCourseDTO.getCreatedAt())
                 .updatedAt(dateCourseDTO.getUpdatedAt())
                 .memberId(dateCourseDTO.getMemberId())
+                .build();
+    }
+
+    public DateCourseDTO fromUpdateScheduleVOToDTO(RequestUpdateDateCourseScheduleVO request, Long courseId) {
+        return DateCourseDTO.builder()
+                .courseId(courseId)
+                .courseStartDate(request.getCourseStartDate())
+                .courseEndDate(request.getCourseEndDate())
                 .build();
     }
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandService.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandService.java
@@ -13,4 +13,8 @@ public interface DateCourseCommandService {
 
     @Transactional
     void deleteDateCourse(Long courseId, CustomUserDetails user);
+
+    void certifyDateCourse(Long courseId, CustomUserDetails user);
+
+    DateCourseDTO updateCourseSchedule(DateCourseDTO dateCourseDTO, CustomUserDetails user);
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandService.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandService.java
@@ -16,5 +16,6 @@ public interface DateCourseCommandService {
 
     void certifyDateCourse(Long courseId, CustomUserDetails user);
 
-    DateCourseDTO updateCourseSchedule(DateCourseDTO dateCourseDTO, CustomUserDetails user);
+    @Transactional
+    DateCourseDTO updateCourseSchedule(DateCourseDTO dateCourseDTO, CustomUserDetails user, String planTypeStr);
 }

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandServiceImpl.java
@@ -7,7 +7,8 @@ import beyond.momentours.date_course.command.application.mapper.DateCourseConver
 import beyond.momentours.date_course.command.domain.aggregate.entity.DateCourse;
 import beyond.momentours.date_course.command.domain.repository.DateCourseRepository;
 import beyond.momentours.date_course.query.repository.DateCourseMapper;
-import beyond.momentours.date_course_location.command.application.service.DateCourseLocationService;
+import beyond.momentours.date_course_location.command.application.service.DateCourseLocationCommandService;
+import beyond.momentours.date_course_location.query.service.DateCourseLocationQueryService;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,8 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
     private final DateCourseRepository dateCourseRepository;
     private final DateCourseConverter dateCourseConverter;
     private final DateCourseMapper dateCourseDAO;
-    private final DateCourseLocationService dateCourseLocationService;
+    private final DateCourseLocationCommandService dateCourseLocationCommandService;
+    private final DateCourseLocationQueryService dateCourseLocationQueryService;
 
     @Transactional
     @Override
@@ -38,7 +40,7 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
             log.info("저장할 데이트 코스 : {}", dateCourse);
             DateCourse savedCourse = dateCourseRepository.save(dateCourse);
 
-            dateCourseLocationService.createDateCourseLocations(savedCourse.getCourseId(), dateCourseDTO.getLocations());
+            dateCourseLocationCommandService.createDateCourseLocations(savedCourse.getCourseId(), dateCourseDTO.getLocations());
 
             log.info("데이트 코스 등록 성공 : {}", savedCourse);
             return dateCourseConverter.fromEntityToDTO(savedCourse);
@@ -74,6 +76,40 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
         log.info("데이트 코스 Soft Delete 완료: courseId={}, userId={}", courseId, user.getMemberId());
     }
 
+    @Transactional
+    @Override
+    public void certifyDateCourse(Long courseId, CustomUserDetails user) {
+        DateCourse dateCourse = dateCourseDAO.findActiveById(courseId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_DATE_COURSE));
+
+        if (!dateCourse.getMemberId().equals(user.getMemberId())) throw new CommonException(ErrorCode.UNAUTHORIZED_ACCESS);
+
+        boolean hasMoment = dateCourseLocationQueryService.hasMomentsInCourse(courseId);
+
+        if (hasMoment) {
+            dateCourse.certifyCourse();
+            dateCourse.updateUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+            dateCourseRepository.save(dateCourse);
+            log.info("데이트 코스 인증 완료: courseId={}, userId={}", courseId, user.getMemberId());
+        } else {
+            throw new CommonException(ErrorCode.NOT_FOUND_MOMENT);
+        }
+    }
+
+    @Transactional
+    @Override
+    public DateCourseDTO updateCourseSchedule(DateCourseDTO dateCourseDTO, CustomUserDetails user) {
+        DateCourse dateCourse = dateCourseRepository.findById(dateCourseDTO.getCourseId()).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_DATE_COURSE));
+
+        if (!dateCourse.getMemberId().equals(user.getMemberId())) throw new CommonException(ErrorCode.UNAUTHORIZED_ACCESS);
+
+        dateCourse.updateSchedule(dateCourseDTO.getCourseStartDate(), dateCourseDTO.getCourseEndDate());
+        dateCourseRepository.save(dateCourse);
+
+        log.info("데이트 코스 일정 업데이트 완료: courseId={}, userId={}, start={}, end={}", dateCourse.getCourseId(), user.getMemberId(), dateCourseDTO.getCourseStartDate(), dateCourseDTO.getCourseEndDate());
+
+        return dateCourseConverter.fromEntityToDTO(dateCourse);
+    }
+
     private void update(DateCourseDTO dateCourseDTO, DateCourse existingCourse, Long courseId) {
         existingCourse.updateCourseTitle(dateCourseDTO.getCourseTitle());
         existingCourse.updateCourseType(dateCourseDTO.getCourseType());
@@ -82,7 +118,7 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
         existingCourse.updateCourseEndDate(dateCourseDTO.getCourseEndDate());
 
         if (dateCourseDTO.getLocations() != null) {
-            dateCourseLocationService.updateDateCourseLocations(courseId, dateCourseDTO.getLocations());
+            dateCourseLocationCommandService.updateDateCourseLocations(courseId, dateCourseDTO.getLocations());
         }
 
         existingCourse.updateUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));

--- a/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/date_course/command/application/service/DateCourseCommandServiceImpl.java
@@ -10,6 +10,9 @@ import beyond.momentours.date_course.query.repository.DateCourseMapper;
 import beyond.momentours.date_course_location.command.application.service.DateCourseLocationCommandService;
 import beyond.momentours.date_course_location.query.service.DateCourseLocationQueryService;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import beyond.momentours.plan.command.application.dto.PlanDTO;
+import beyond.momentours.plan.command.application.service.PlanCommandService;
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +22,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 @Slf4j
-@Service("commandDateCourseService")
+@Service
 @RequiredArgsConstructor
 public class DateCourseCommandServiceImpl implements DateCourseCommandService {
 
@@ -28,6 +31,7 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
     private final DateCourseMapper dateCourseDAO;
     private final DateCourseLocationCommandService dateCourseLocationCommandService;
     private final DateCourseLocationQueryService dateCourseLocationQueryService;
+    private final PlanCommandService planCommandService;
 
     @Transactional
     @Override
@@ -97,9 +101,8 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
 
     @Transactional
     @Override
-    public DateCourseDTO updateCourseSchedule(DateCourseDTO dateCourseDTO, CustomUserDetails user) {
+    public DateCourseDTO updateCourseSchedule(DateCourseDTO dateCourseDTO, CustomUserDetails user, String planTypeStr) {
         DateCourse dateCourse = dateCourseRepository.findById(dateCourseDTO.getCourseId()).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_DATE_COURSE));
-
         if (!dateCourse.getMemberId().equals(user.getMemberId())) throw new CommonException(ErrorCode.UNAUTHORIZED_ACCESS);
 
         dateCourse.updateSchedule(dateCourseDTO.getCourseStartDate(), dateCourseDTO.getCourseEndDate());
@@ -107,7 +110,31 @@ public class DateCourseCommandServiceImpl implements DateCourseCommandService {
 
         log.info("데이트 코스 일정 업데이트 완료: courseId={}, userId={}, start={}, end={}", dateCourse.getCourseId(), user.getMemberId(), dateCourseDTO.getCourseStartDate(), dateCourseDTO.getCourseEndDate());
 
+        PlanType planType = getPlanTypeFromString(planTypeStr);
+        PlanDTO planDTO = PlanDTO.builder()
+                .planType(planType)
+                .planTitle(dateCourseDTO.getCourseTitle())
+                .planContent(dateCourseDTO.getCourseTitle() + "데이트 코스 일정")
+                .planStartDate(dateCourseDTO.getCourseStartDate())
+                .planEndDate(dateCourseDTO.getCourseEndDate())
+                .courseId(dateCourseDTO.getCourseId())
+                .build();
+
+        planCommandService.createPlan(planDTO, user);
+        log.info("데이트 코스에 따른 일정 등록 완료: courseId={}, planType={}", dateCourse.getCourseId(), planType);
+
         return dateCourseConverter.fromEntityToDTO(dateCourse);
+    }
+
+    private PlanType getPlanTypeFromString(String planTypeStr) {
+        if (planTypeStr == null) {
+            return PlanType.PERSONAL_TRIP;
+        }
+        try {
+            return PlanType.valueOf(planTypeStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     private void update(DateCourseDTO dateCourseDTO, DateCourse existingCourse, Long courseId) {

--- a/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/aggregate/entity/DateCourse.java
@@ -107,4 +107,21 @@ public class DateCourse {
     public void deleteCourse(Boolean courseStatus) {
         this.courseStatus = courseStatus;
     }
+
+    public void certifyCourse() {
+        this.courseCertification = true;
+    }
+
+    public void updateSchedule(LocalDateTime courseStartDate, LocalDateTime courseEndDate) {
+        if (courseStartDate == null || courseEndDate == null) {
+            throw new IllegalArgumentException("시작 날짜와 종료 날짜를 모두 입력해야 합니다.");
+        }
+        if (courseEndDate.isBefore(courseStartDate)) {
+            throw new IllegalArgumentException("종료 날짜는 시작 날짜보다 이후여야 합니다.");
+        }
+
+        this.courseStartDate = courseStartDate;
+        this.courseEndDate = courseEndDate;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestCreateDateCourseVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestCreateDateCourseVO.java
@@ -4,7 +4,6 @@ import beyond.momentours.date_course.command.domain.aggregate.CourseType;
 import beyond.momentours.date_course_location.command.domain.vo.DateCourseLocationVO;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -16,8 +15,6 @@ public class RequestCreateDateCourseVO {
     private String courseTitle;
     private CourseType courseType;
     private Boolean courseDisclosure;
-    private LocalDateTime courseStartDate;
-    private LocalDateTime courseEndDate;
     private Long folderId;
 
     private List<DateCourseLocationVO> locations;

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestUpdateDateCourseScheduleVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestUpdateDateCourseScheduleVO.java
@@ -1,20 +1,22 @@
 package beyond.momentours.date_course.command.domain.vo.request;
 
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
 public class RequestUpdateDateCourseScheduleVO {
-
-    @NotNull(message = "시작 날짜를 입력해야 합니다.")
+    @JsonProperty("course_start_date")
     private LocalDateTime courseStartDate;
 
-    @NotNull(message = "종료 날짜를 입력해야 합니다.")
+    @JsonProperty("course_end_date")
     private LocalDateTime courseEndDate;
+
+    @JsonProperty("plan_type")
+    private String planType;
 }

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestUpdateDateCourseScheduleVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestUpdateDateCourseScheduleVO.java
@@ -1,0 +1,20 @@
+package beyond.momentours.date_course.command.domain.vo.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestUpdateDateCourseScheduleVO {
+
+    @NotNull(message = "시작 날짜를 입력해야 합니다.")
+    private LocalDateTime courseStartDate;
+
+    @NotNull(message = "종료 날짜를 입력해야 합니다.")
+    private LocalDateTime courseEndDate;
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestUpdateDateCourseVO.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/vo/request/RequestUpdateDateCourseVO.java
@@ -4,7 +4,6 @@ import beyond.momentours.date_course.command.domain.aggregate.CourseType;
 import beyond.momentours.date_course_location.command.domain.vo.DateCourseLocationVO;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -16,8 +15,6 @@ public class RequestUpdateDateCourseVO {
     private String courseTitle;
     private CourseType courseType;
     private Boolean courseDisclosure;
-    private LocalDateTime courseStartDate;
-    private LocalDateTime courseEndDate;
 
     private List<DateCourseLocationVO> locations;
 }

--- a/src/main/java/beyond/momentours/date_course_location/command/application/service/DateCourseLocationCommandService.java
+++ b/src/main/java/beyond/momentours/date_course_location/command/application/service/DateCourseLocationCommandService.java
@@ -5,7 +5,7 @@ import jakarta.transaction.Transactional;
 
 import java.util.List;
 
-public interface DateCourseLocationService {
+public interface DateCourseLocationCommandService {
     void createDateCourseLocations(Long courseId, List<DateCourseLocationVO> locations);
 
     @Transactional

--- a/src/main/java/beyond/momentours/date_course_location/command/application/service/DateCourseLocationCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/date_course_location/command/application/service/DateCourseLocationCommandServiceImpl.java
@@ -15,9 +15,9 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Slf4j
-@Service("commandDateCourseLocationService")
+@Service
 @RequiredArgsConstructor
-public class DateCourseLocationServiceImpl implements DateCourseLocationService {
+public class DateCourseLocationCommandServiceImpl implements DateCourseLocationCommandService {
 
     private final LocationService locationService;
     private final DateCourseLocationRepository dateCourseLocationRepository;

--- a/src/main/java/beyond/momentours/date_course_location/query/repository/DateCourseLocationMapper.java
+++ b/src/main/java/beyond/momentours/date_course_location/query/repository/DateCourseLocationMapper.java
@@ -1,0 +1,13 @@
+package beyond.momentours.date_course_location.query.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface DateCourseLocationMapper {
+    List<Long> findLocationIdsByCourseId(@Param("courseId") Long courseId);
+
+    int countMomentsByLocationIds(@Param("list") List<Long> locationIds);
+}

--- a/src/main/java/beyond/momentours/date_course_location/query/service/DateCourseLocationQueryService.java
+++ b/src/main/java/beyond/momentours/date_course_location/query/service/DateCourseLocationQueryService.java
@@ -1,0 +1,5 @@
+package beyond.momentours.date_course_location.query.service;
+
+public interface DateCourseLocationQueryService {
+    boolean hasMomentsInCourse(Long courseId);
+}

--- a/src/main/java/beyond/momentours/date_course_location/query/service/DateCourseLocationQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/date_course_location/query/service/DateCourseLocationQueryServiceImpl.java
@@ -1,0 +1,25 @@
+package beyond.momentours.date_course_location.query.service;
+
+import beyond.momentours.date_course_location.query.repository.DateCourseLocationMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DateCourseLocationQueryServiceImpl implements DateCourseLocationQueryService{
+
+    private final DateCourseLocationMapper dateCourseLocationMapper;
+
+    @Override
+    public boolean hasMomentsInCourse(Long courseId) {
+        List<Long> locationIds = dateCourseLocationMapper.findLocationIdsByCourseId(courseId);
+        if (locationIds.isEmpty()) return false;
+
+        int count = dateCourseLocationMapper.countMomentsByLocationIds(locationIds);
+        return count > 0;
+    }
+}

--- a/src/main/java/beyond/momentours/plan/command/application/controller/PlanCommandController.java
+++ b/src/main/java/beyond/momentours/plan/command/application/controller/PlanCommandController.java
@@ -4,7 +4,7 @@ import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import beyond.momentours.plan.command.application.dto.PlanDTO;
 import beyond.momentours.plan.command.application.mapper.PlanConverter;
-import beyond.momentours.plan.command.application.service.PlanService;
+import beyond.momentours.plan.command.application.service.PlanCommandService;
 import beyond.momentours.plan.command.domain.vo.request.RequestUpdatePlanVO;
 import beyond.momentours.plan.command.domain.vo.request.RequestCreatePlanVO;
 import beyond.momentours.plan.command.domain.vo.response.ResponseUpdatePlanVO;
@@ -16,15 +16,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-@RestController("commandPlanController")
+@RestController
 @RequestMapping("api/plan")
 @Slf4j
 @RequiredArgsConstructor
-public class PlanController {
+public class PlanCommandController {
 
-    private final PlanService planService;
+    private final PlanCommandService planCommandService;
     private final PlanConverter planConverter;
 
     @PostMapping
@@ -32,7 +30,7 @@ public class PlanController {
         log.info("등록 요청된 request 데이터 : {}", request);
         try {
             PlanDTO planDTO = planConverter.fromCreateVOToDTO(request);
-            PlanDTO savePlanDTO = planService.createPlan(planDTO, user);
+            PlanDTO savePlanDTO = planCommandService.createPlan(planDTO, user);
             ResponseCreatePlanVO response = planConverter.fromDTOToCreateVO(savePlanDTO);
 
             return ResponseEntity.status(HttpStatus.OK).body(response);
@@ -50,7 +48,7 @@ public class PlanController {
         log.info("수정 요청된 request 데이터 : {}", request);
         try {
             PlanDTO planDTO = planConverter.fromUpdateVOToDTO(request);
-            PlanDTO updatedPlan = planService.updatePlan(planDTO, user);
+            PlanDTO updatedPlan = planCommandService.updatePlan(planDTO, user);
             ResponseUpdatePlanVO response = planConverter.fromDTOToUpdateVO(updatedPlan);
 
             return ResponseEntity.status(HttpStatus.OK).body(response);
@@ -67,57 +65,12 @@ public class PlanController {
     public ResponseEntity<?> deletePlan(@PathVariable Long planId, @AuthenticationPrincipal CustomUserDetails user) {
         log.info("삭제 요청한 일정 ID : {}", planId);
         try {
-            PlanDTO deletedPlan = planService.deletePlan(planId, user);
+            PlanDTO deletedPlan = planCommandService.deactivatePlan(planId, user);
             log.info("삭제된 planId : {}, 해당 일정의 상태 : {}", deletedPlan.getPlanId(), deletedPlan.getPlanStatus());
             return ResponseEntity.status(HttpStatus.OK).body("성공적으로 삭제되었습니다.");
         } catch (CommonException e) {
             log.error("일정 삭제 오류: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        } catch (Exception e) {
-            log.error("예상치 못한 오류", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
-        }
-    }
-
-    @GetMapping("/schedules")
-    public ResponseEntity<?> getPlans(@RequestParam int year, @RequestParam int month, @AuthenticationPrincipal CustomUserDetails user) {
-        log.info("스케줄 월별 조회 요청 year: {}, month: {}", year, month);
-        try {
-            List<PlanDTO> plans = planService.getPlans(year, month, user);
-            return ResponseEntity.status(HttpStatus.OK).body(plans);
-        } catch (CommonException e) {
-            log.error("스케줄 월별 조회 오류: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        } catch (Exception e) {
-            log.error("예상치 못한 오류", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
-        }
-    }
-
-    @GetMapping("/schedules/date")
-    public ResponseEntity<?> getPlansByDate(@RequestParam int year, @RequestParam int month, @RequestParam int day, @AuthenticationPrincipal CustomUserDetails user) {
-        log.info("특정 날짜 일정 요청 year: {}, month: {}, day: {}", year, month, day);
-        try {
-            List<PlanDTO> plansByDate = planService.getPlansByDate(year, month, day, user);
-            return ResponseEntity.status(HttpStatus.OK).body(plansByDate);
-        } catch (CommonException e) {
-            log.error("스케줄 특정 날짜 조회 오류: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        } catch (Exception e) {
-            log.error("예상치 못한 오류", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
-        }
-    }
-
-    @GetMapping("/{planId}")
-    public ResponseEntity<?> getPlanById(@PathVariable Long planId) {
-        log.info("조회 요청된 planId: {}", planId);
-        try {
-            PlanDTO plan = planService.getPlanById(planId);
-            return ResponseEntity.status(HttpStatus.OK).body(plan);
-        } catch (CommonException e) {
-            log.error("스케줄 조회 오류: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         } catch (Exception e) {
             log.error("예상치 못한 오류", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");

--- a/src/main/java/beyond/momentours/plan/command/application/dto/PlanDTO.java
+++ b/src/main/java/beyond/momentours/plan/command/application/dto/PlanDTO.java
@@ -1,5 +1,6 @@
 package beyond.momentours.plan.command.application.dto;
 
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 public class PlanDTO {
     private Long planId;
+    private PlanType planType;
     private String planTitle;
     private String planContent;
     private LocalDateTime planStartDate;

--- a/src/main/java/beyond/momentours/plan/command/application/mapper/PlanConverter.java
+++ b/src/main/java/beyond/momentours/plan/command/application/mapper/PlanConverter.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class PlanConverter {
     public PlanDTO fromCreateVOToDTO(RequestCreatePlanVO registerPlanVO) {
         return PlanDTO.builder()
+                .planType(registerPlanVO.getPlanType())
                 .planTitle(registerPlanVO.getPlanTitle())
                 .planContent(registerPlanVO.getPlanContent())
                 .planStartDate(registerPlanVO.getPlanStartDate())
@@ -23,6 +24,7 @@ public class PlanConverter {
 
     public ResponseCreatePlanVO fromDTOToCreateVO(PlanDTO savePlanDTO) {
         return ResponseCreatePlanVO.builder()
+                .planType(savePlanDTO.getPlanType())
                 .planTitle(savePlanDTO.getPlanTitle())
                 .planContent(savePlanDTO.getPlanContent())
                 .planStartDate(savePlanDTO.getPlanStartDate())
@@ -35,6 +37,7 @@ public class PlanConverter {
 
     public Plan fromDTOToEntity(PlanDTO planDTO, Long coupleId) {
         return Plan.builder()
+                .planType(planDTO.getPlanType())
                 .planTitle(planDTO.getPlanTitle())
                 .planContent(planDTO.getPlanContent())
                 .planStartDate(planDTO.getPlanStartDate())
@@ -49,6 +52,7 @@ public class PlanConverter {
     public PlanDTO fromEntityToDTO(Plan plan) {
         return PlanDTO.builder()
                 .planId(plan.getPlanId())
+                .planType(plan.getPlanType())
                 .planTitle(plan.getPlanTitle())
                 .planContent(plan.getPlanContent())
                 .planStartDate(plan.getPlanStartDate())
@@ -64,6 +68,7 @@ public class PlanConverter {
 
     public PlanDTO fromUpdateVOToDTO(RequestUpdatePlanVO editPlanVO) {
         return PlanDTO.builder()
+                .planType(editPlanVO.getPlanType())
                 .planTitle(editPlanVO.getPlanTitle())
                 .planContent(editPlanVO.getPlanContent())
                 .planStartDate(editPlanVO.getPlanStartDate())
@@ -76,6 +81,7 @@ public class PlanConverter {
     public ResponseUpdatePlanVO fromDTOToUpdateVO(PlanDTO editedPlan) {
         return ResponseUpdatePlanVO.builder()
                 .planId(editedPlan.getPlanId())
+                .planType(editedPlan.getPlanType())
                 .planTitle(editedPlan.getPlanTitle())
                 .planContent(editedPlan.getPlanContent())
                 .planStartDate(editedPlan.getPlanStartDate())

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandService.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandService.java
@@ -6,7 +6,7 @@ import jakarta.transaction.Transactional;
 
 import java.util.List;
 
-public interface PlanService {
+public interface PlanCommandService {
     @Transactional
     PlanDTO createPlan(PlanDTO planDTO, CustomUserDetails user);
 
@@ -14,11 +14,5 @@ public interface PlanService {
     PlanDTO updatePlan(PlanDTO planDTO, CustomUserDetails user);
 
     @Transactional
-    PlanDTO deletePlan(Long planId, CustomUserDetails user);
-
-    List<PlanDTO> getPlans(int year, int month, CustomUserDetails user);
-
-    List<PlanDTO> getPlansByDate(int year, int month, int day, CustomUserDetails user);
-
-    PlanDTO getPlanById(Long planId);
+    PlanDTO deactivatePlan(Long planId, CustomUserDetails user);
 }

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandService.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandService.java
@@ -4,8 +4,6 @@ import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import beyond.momentours.plan.command.application.dto.PlanDTO;
 import jakarta.transaction.Transactional;
 
-import java.util.List;
-
 public interface PlanCommandService {
     @Transactional
     PlanDTO createPlan(PlanDTO planDTO, CustomUserDetails user);

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandServiceImpl.java
@@ -5,6 +5,7 @@ import beyond.momentours.common.exception.ErrorCode;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import beyond.momentours.plan.command.application.mapper.PlanConverter;
 import beyond.momentours.plan.command.application.dto.PlanDTO;
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import beyond.momentours.plan.command.domain.aggregate.entity.Plan;
 import beyond.momentours.plan.command.domain.repository.PlanRepository;
 import beyond.momentours.plan.query.repository.PlanMapper;
@@ -12,13 +13,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Slf4j
-@Service("commandPlanService")
+@Service
 @RequiredArgsConstructor
-public class PlanServiceImpl implements PlanService {
+public class PlanCommandServiceImpl implements PlanCommandService {
 
     private final PlanRepository planRepository;
     private final PlanConverter planConverter;
@@ -27,21 +25,28 @@ public class PlanServiceImpl implements PlanService {
     @Override
     public PlanDTO createPlan(PlanDTO planDTO, CustomUserDetails user) {
         Long memberId = user.getMemberId();
+        Long coupleId = null;
+
+        if (planDTO.getPlanType() == PlanType.COUPLE || planDTO.getPlanType() == PlanType.COUPLE_TRIP) {
+            coupleId = planDAO.findByCoupleId(memberId);
+            if (coupleId == null) throw new CommonException(ErrorCode.NOT_FOUND_COUPLE);
+            memberId = null;
+        } else if (planDTO.getPlanType() == PlanType.PERSONAL || planDTO.getPlanType() == PlanType.PERSONAL_TRIP) {
+            coupleId = null;
+        }
+
+        log.info("planType: {}, memberId: {}, coupleId: {}", planDTO.getPlanType(), memberId, coupleId);
+
         planDTO.setMemberId(memberId);
-
-        Long coupleId = planDAO.findByCoupleId(memberId);
-        log.info("memberId : {} , coupleId : {}", memberId, coupleId);
-
         Plan plan = planConverter.fromDTOToEntity(planDTO, coupleId);
 
         if (planDTO.getCourseId() != null) {
             Long courseId = planDAO.findByCourseId(planDTO.getCourseId());
             log.info("courseId : {}", courseId);
-
             plan.setCourseId(plan, courseId);
         }
-        log.info("저장 전 plan : {}", plan);
 
+        log.info("저장 전 plan : {}", plan);
         plan.register(plan);
         planRepository.save(plan);
         log.info("저장 후 plan : {}", plan);
@@ -74,8 +79,7 @@ public class PlanServiceImpl implements PlanService {
     }
 
     @Override
-    public PlanDTO deletePlan(Long planId, CustomUserDetails user) {
-        // Plan 조회
+    public PlanDTO deactivatePlan(Long planId, CustomUserDetails user) {
         Plan existingPlan = planRepository.findById(planId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PLAN));
         log.info("삭제 요청된 Plan 데이터: {}", existingPlan);
 
@@ -88,57 +92,12 @@ public class PlanServiceImpl implements PlanService {
             throw new CommonException(ErrorCode.ACCESS_DENIED);
         }
 
-        existingPlan.updateStatus(false);
+        existingPlan.updateStatus(false);  // 상태를 비활성화로 변경
         log.info("상태 변경 후 Plan : {}", existingPlan);
 
         planRepository.save(existingPlan);
 
         return planConverter.fromEntityToDTO(existingPlan);
-    }
-
-    @Override
-    public List<PlanDTO> getPlans(int year, int month, CustomUserDetails user) {
-        LocalDateTime planStartDate = LocalDateTime.of(year, month, 1, 0, 0, 0);
-        LocalDateTime planEndDate = planStartDate.withDayOfMonth(planStartDate.toLocalDate().lengthOfMonth())
-                .withHour(23)
-                .withMinute(59)
-                .withSecond(59);
-
-        log.info("스케줄 조회 - 시작 날짜: {}, 종료 날짜: {}", planStartDate, planEndDate);
-
-        Long memberId = user.getMemberId();
-        Long coupleId = planDAO.findByCoupleId(memberId);
-        log.info("memberId : {} , coupleId : {}", memberId, coupleId);
-
-        List<Plan> plans = planDAO.findByCoupleIdAndDateRange(coupleId, planStartDate, planEndDate);
-
-        return plans.stream()
-                .map(planConverter::fromEntityToDTO)
-                .toList();
-    }
-
-    @Override
-    public List<PlanDTO> getPlansByDate(int year, int month, int day, CustomUserDetails user) {
-        LocalDateTime selectedDateStart = LocalDateTime.of(year, month, day, 0, 0, 0);
-        LocalDateTime selectedDateEnd = LocalDateTime.of(year, month, day, 23, 59, 59);
-
-        log.info("특정 날짜 일정 조회 - 시작: {}, 종료: {}", selectedDateStart, selectedDateEnd);
-
-        Long memberId = user.getMemberId();
-        Long coupleId = planDAO.findByCoupleId(memberId);
-
-        List<Plan> plans = planDAO.findByDate(coupleId, selectedDateStart, selectedDateEnd);
-
-        return plans.stream()
-                .map(planConverter::fromEntityToDTO)
-                .toList();
-    }
-
-    @Override
-    public PlanDTO getPlanById(Long planId) {
-        Plan plan = planRepository.findById(planId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PLAN));
-
-        return planConverter.fromEntityToDTO(plan);
     }
 
     private void updatePlan(PlanDTO planDTO, Plan existingPlan) {

--- a/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/plan/command/application/service/PlanCommandServiceImpl.java
@@ -92,7 +92,7 @@ public class PlanCommandServiceImpl implements PlanCommandService {
             throw new CommonException(ErrorCode.ACCESS_DENIED);
         }
 
-        existingPlan.updateStatus(false);  // 상태를 비활성화로 변경
+        existingPlan.updateStatus(false);
         log.info("상태 변경 후 Plan : {}", existingPlan);
 
         planRepository.save(existingPlan);
@@ -112,5 +112,4 @@ public class PlanCommandServiceImpl implements PlanCommandService {
             existingPlan.updateCourseId(courseId);
         }
     }
-
 }

--- a/src/main/java/beyond/momentours/plan/command/domain/aggregate/PlanType.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/aggregate/PlanType.java
@@ -1,0 +1,19 @@
+package beyond.momentours.plan.command.domain.aggregate;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum PlanType {
+    PERSONAL("PERSONAL"),
+    COUPLE("COUPLE"),
+    PERSONAL_TRIP("PERSONAL_TRIP"),
+    COUPLE_TRIP("COUPLE_TRIP");
+
+    private final String planType;
+
+    PlanType(String planType) { this.planType = planType; }
+
+    @JsonValue
+    public String getType() {
+        return planType;
+    }
+}

--- a/src/main/java/beyond/momentours/plan/command/domain/aggregate/entity/Plan.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/aggregate/entity/Plan.java
@@ -1,5 +1,8 @@
 package beyond.momentours.plan.command.domain.aggregate.entity;
 
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,6 +21,9 @@ public class Plan {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "plan_id")
     private Long planId;
+
+    @Column(name = "plan_type", nullable = false)
+    private PlanType planType;
 
     @Column(name = "plan_title", nullable = false)
     private String planTitle;
@@ -62,6 +68,10 @@ public class Plan {
     public void register(Plan plan) {
         plan.createdAt = LocalDateTime.now();
         plan.updatedAt = LocalDateTime.now();
+
+        if (plan.getPlanType() == PlanType.COUPLE && plan.getCoupleId() == null) {
+            throw new CommonException(ErrorCode.NOT_FOUND_COUPLE);
+        }
     }
 
     public void setCourseId(Plan plan, Long courseId) {

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestCreatePlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestCreatePlanVO.java
@@ -1,5 +1,6 @@
 package beyond.momentours.plan.command.domain.vo.request;
 
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -11,6 +12,9 @@ import java.time.LocalDateTime;
 @Builder
 @ToString
 public class RequestCreatePlanVO {
+    @JsonProperty("plan_type")
+    private PlanType planType;
+
     @JsonProperty("plan_title")
     private String planTitle;
 

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestUpdatePlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/request/RequestUpdatePlanVO.java
@@ -1,5 +1,6 @@
 package beyond.momentours.plan.command.domain.vo.request;
 
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -13,6 +14,9 @@ import java.time.LocalDateTime;
 public class RequestUpdatePlanVO {
     @JsonProperty("plan_id")
     private Long planId;
+
+    @JsonProperty("plan_type")
+    private PlanType planType;
 
     @JsonProperty("plan_title")
     private String planTitle;

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseCreatePlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseCreatePlanVO.java
@@ -1,5 +1,6 @@
 package beyond.momentours.plan.command.domain.vo.response;
 
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -12,6 +13,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 public class ResponseCreatePlanVO {
+    @JsonProperty("plan_type")
+    private PlanType planType;
+
     @JsonProperty("plan_title")
     private String planTitle;
 

--- a/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseUpdatePlanVO.java
+++ b/src/main/java/beyond/momentours/plan/command/domain/vo/response/ResponseUpdatePlanVO.java
@@ -1,5 +1,6 @@
 package beyond.momentours.plan.command.domain.vo.response;
 
+import beyond.momentours.plan.command.domain.aggregate.PlanType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -14,6 +15,9 @@ import java.time.LocalDateTime;
 public class ResponseUpdatePlanVO {
     @JsonProperty("plan_id")
     private Long planId;
+
+    @JsonProperty("plan_type")
+    private PlanType planType;
 
     @JsonProperty("plan_title")
     private String planTitle;

--- a/src/main/java/beyond/momentours/plan/query/controller/controller/PlanQueryController.java
+++ b/src/main/java/beyond/momentours/plan/query/controller/controller/PlanQueryController.java
@@ -1,0 +1,72 @@
+package beyond.momentours.plan.query.controller.controller;
+
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import beyond.momentours.plan.command.application.dto.PlanDTO;
+import beyond.momentours.plan.query.service.PlanQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/plan")
+@Slf4j
+@RequiredArgsConstructor
+public class PlanQueryController {
+
+    private final PlanQueryService planQueryService;
+
+    @Operation(description = "스케줄 월별 조회 요청")
+    @GetMapping("/schedules")
+    public ResponseEntity<?> getPlans(@RequestParam int year, @RequestParam int month, @RequestParam(required = false) List<String> type, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("스케줄 월별 조회 요청 year: {}, month: {}, type: {}", year, month, type);
+        try {
+            List<PlanDTO> plans = planQueryService.getPlans(year, month, type, user);
+            return ResponseEntity.ok(plans);
+        } catch (CommonException e) {
+            log.error("스케줄 월별 조회 오류: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.internalServerError().body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @Operation(description = "특정 날짜의 일정들 조회 요청")
+    @GetMapping("/schedules/date")
+    public ResponseEntity<?> getPlansByDate(@RequestParam int year, @RequestParam int month, @RequestParam int day, @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("특정 날짜 일정 요청 year: {}, month: {}, day: {}", year, month, day);
+        try {
+            List<PlanDTO> plansByDate = planQueryService.getPlansByDate(year, month, day, user);
+            return ResponseEntity.status(HttpStatus.OK).body(plansByDate);
+        } catch (CommonException e) {
+            log.error("스케줄 특정 날짜 조회 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @Operation(description = "특정 일정 조회")
+    @GetMapping("/{planId}")
+    public ResponseEntity<?> getPlanById(@PathVariable Long planId) {
+        log.info("조회 요청된 planId: {}", planId);
+        try {
+            PlanDTO plan = planQueryService.getPlanById(planId);
+            return ResponseEntity.status(HttpStatus.OK).body(plan);
+        } catch (CommonException e) {
+            log.error("스케줄 조회 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+}

--- a/src/main/java/beyond/momentours/plan/query/repository/PlanMapper.java
+++ b/src/main/java/beyond/momentours/plan/query/repository/PlanMapper.java
@@ -14,7 +14,7 @@ public interface PlanMapper {
 
     Long findByCourseId(Long courseId);
 
-    List<Plan> findByCoupleIdAndDateRange(@Param("coupleId") Long coupleId, @Param("planStartDate") LocalDateTime planStartDate, @Param("planEndDate") LocalDateTime planEndDate);
+    List<Plan> findByTypeAndDateRange(@Param("coupleId") Long coupleId, @Param("planStartDate") LocalDateTime planStartDate, @Param("planEndDate") LocalDateTime planEndDate, @Param("types") List<String> types);
 
-    List<Plan> findByDate(@Param("coupleId") Long coupleId, @Param("selectedDateStart") LocalDateTime selectedDateStart, @Param("selectedDateEnd") LocalDateTime selectedDateEnd);
+    List<Plan> findByMemberOrCoupleIdAndDateRange(@Param("memberId") Long memberId, @Param("coupleId") Long coupleId, @Param("planStartDate") LocalDateTime planStartDate, @Param("planEndDate") LocalDateTime planEndDate);
 }

--- a/src/main/java/beyond/momentours/plan/query/service/PlanQueryService.java
+++ b/src/main/java/beyond/momentours/plan/query/service/PlanQueryService.java
@@ -1,0 +1,14 @@
+package beyond.momentours.plan.query.service;
+
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import beyond.momentours.plan.command.application.dto.PlanDTO;
+
+import java.util.List;
+
+public interface PlanQueryService {
+    List<PlanDTO> getPlans(int year, int month, List<String> types, CustomUserDetails user);
+
+    List<PlanDTO> getPlansByDate(int year, int month, int day, CustomUserDetails user);
+
+    PlanDTO getPlanById(Long planId);
+}

--- a/src/main/java/beyond/momentours/plan/query/service/PlanQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/plan/query/service/PlanQueryServiceImpl.java
@@ -1,0 +1,70 @@
+package beyond.momentours.plan.query.service;
+
+import beyond.momentours.common.exception.CommonException;
+import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import beyond.momentours.plan.command.application.dto.PlanDTO;
+import beyond.momentours.plan.command.application.mapper.PlanConverter;
+import beyond.momentours.plan.command.domain.aggregate.entity.Plan;
+import beyond.momentours.plan.command.domain.repository.PlanRepository;
+import beyond.momentours.plan.query.repository.PlanMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlanQueryServiceImpl implements PlanQueryService {
+
+    private final PlanRepository planRepository;
+    private final PlanConverter planConverter;
+    private final PlanMapper planDAO;
+
+    @Override
+    public List<PlanDTO> getPlans(int year, int month, List<String> types, CustomUserDetails user) {
+        LocalDateTime planStartDate = LocalDateTime.of(year, month, 1, 0, 0, 0);
+        LocalDateTime planEndDate = planStartDate.withDayOfMonth(planStartDate.toLocalDate().lengthOfMonth())
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(59);
+
+        log.info("스케줄 조회 - 시작 날짜: {}, 종료 날짜: {}, type: {}", planStartDate, planEndDate, types);
+
+        Long memberId = user.getMemberId();
+        Long coupleId = planDAO.findByCoupleId(memberId);
+
+        List<Plan> plans = planDAO.findByTypeAndDateRange(coupleId, planStartDate, planEndDate, types);
+
+        return plans.stream()
+                .map(planConverter::fromEntityToDTO)
+                .toList();
+    }
+
+    @Override
+    public List<PlanDTO> getPlansByDate(int year, int month, int day, CustomUserDetails user) {
+        LocalDateTime selectedDateStart = LocalDateTime.of(year, month, day, 0, 0, 0);
+        LocalDateTime selectedDateEnd = LocalDateTime.of(year, month, day, 23, 59, 59);
+
+        log.info("특정 날짜 일정 조회 - 시작: {}, 종료: {}", selectedDateStart, selectedDateEnd);
+
+        Long memberId = user.getMemberId();
+        Long coupleId = planDAO.findByCoupleId(memberId);
+
+        List<Plan> plans = planDAO.findByMemberOrCoupleIdAndDateRange(memberId, coupleId, selectedDateStart, selectedDateEnd);
+
+        return plans.stream()
+                .map(planConverter::fromEntityToDTO)
+                .toList();
+    }
+
+    @Override
+    public PlanDTO getPlanById(Long planId) {
+        Plan plan = planRepository.findById(planId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_PLAN));
+
+        return planConverter.fromEntityToDTO(plan);
+    }
+}

--- a/src/main/resources/beyond/momentours/mapper/date_course_location/DateCourseLocationMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/date_course_location/DateCourseLocationMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="beyond.momentours.date_course_location.query.repository.DateCourseLocationMapper">
+
+    <select id="findLocationIdsByCourseId" parameterType="long" resultType="long">
+        SELECT location_id
+        FROM tb_date_course_location
+        WHERE course_id = #{courseId}
+    </select>
+
+    <select id="countMomentsByLocationIds" parameterType="list" resultType="int">
+        SELECT COUNT(*)
+        FROM tb_moment
+        WHERE location_id IN
+        <foreach item="id" collection="list" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+
+</mapper>

--- a/src/main/resources/beyond/momentours/mapper/plan/PlanMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/plan/PlanMapper.xml
@@ -4,8 +4,10 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="beyond.momentours.plan.query.repository.PlanMapper">
+
     <resultMap id="planResultMap" type="beyond.momentours.plan.command.domain.aggregate.entity.Plan">
         <id property="planId" column="plan_id"/>
+        <result property="planType" column="plan_type"/>
         <result property="planTitle" column="plan_title"/>
         <result property="planContent" column="plan_content"/>
         <result property="planStartDate" column="plan_start_date"/>
@@ -18,37 +20,42 @@
         <result property="courseId" column="course_id"/>
     </resultMap>
 
-    <select id="findByCoupleId" resultType="int" parameterType="int">
+    <select id="findByCoupleId" resultType="long" parameterType="long">
         SELECT couple_id
-          FROM tb_couplelist
-         WHERE (member_id = #{memberId1} OR (member_id = #{memberId2})
-           AND couple_status = 1;
+        FROM tb_couplelist
+        WHERE (member_id = #{memberId})
+        AND couple_status = 1;
     </select>
 
-    <select id="findByCourseId" resultType="int" parameterType="int">
+    <select id="findByCourseId" resultType="long" parameterType="long">
         SELECT course_id
-          FROM tb_date_course
-         WHERE course_id = #{courseId}
-           AND course_status = 1;
+        FROM tb_date_course
+        WHERE course_id = #{courseId}
+        AND course_status = 1;
     </select>
 
-    <select id="findByCoupleIdAndDateRange" resultMap="planResultMap">
-        SELECT plan_id, plan_title, plan_content, plan_start_date, plan_end_date, plan_status, created_at, updated_at, member_id, couple_id, course_id
-          FROM tb_plan
-         WHERE couple_id = #{coupleId}
-           AND plan_start_date >= #{planStartDate}
-           AND plan_end_date &lt;= #{planEndDate}
-           AND plan_status = 1;
+    <select id="findByTypeAndDateRange" resultMap="planResultMap">
+        SELECT plan_id, plan_type, plan_title, plan_content, plan_start_date, plan_end_date, plan_status, created_at, updated_at, member_id, couple_id, course_id
+        FROM tb_plan
+        WHERE (couple_id = #{coupleId} OR member_id = #{memberId})
+        AND plan_start_date &lt;= #{planEndDate}
+        AND plan_end_date >= #{planStartDate}
+        AND plan_status = 1
+        <if test="types != null and types.size() > 0">
+            AND plan_type IN
+            <foreach item="type" collection="types" open="(" separator="," close=")">
+                #{type}
+            </foreach>
+        </if>
     </select>
 
-    <select id="findByDate" resultMap="planResultMap">
-        SELECT plan_id, plan_title, plan_content, plan_start_date, plan_end_date, plan_status, created_at, updated_at, member_id, couple_id, course_id
-          FROM tb_plan
-         WHERE couple_id = #{coupleId}
-           AND plan_start_date &lt;= #{selectedDateEnd}
-           AND plan_end_date >= #{selectedDateStart}
-           AND plan_end_date &lt;= #{planEndDate}
-           AND plan_status = 1;
+    <select id="findByMemberOrCoupleIdAndDateRange" resultMap="planResultMap">
+        SELECT plan_id, plan_type, plan_title, plan_content, plan_start_date, plan_end_date, plan_status, created_at, updated_at, member_id, couple_id, course_id
+        FROM tb_plan
+        WHERE (member_id = #{memberId} OR couple_id = #{coupleId})
+        AND plan_start_date &lt;= #{planEndDate}
+        AND plan_end_date >= #{planStartDate}
+        AND plan_status = 1;
     </select>
 
 </mapper>


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 데이트 코스에서 증명이 됐는지에 따른 것을 추억을 통해 나타내게끔 추가했습니다.
- 데이트 코스(내 코스) 에서 특정 코스를 일정에 등록하고 싶을 때 시작일, 종료일, 개인/커플 인지에 따른 타입까지 요청 받아 일정에 등록되는 기능을 추가했습니다.

  <br/>