### PR TITLE
feat(#92, #93): 회원가입 이메일&닉네임 중복확인, 인증번호 4자리

### DIFF
--- a/src/main/java/beyond/momentours/common/exception/ErrorCode.java
+++ b/src/main/java/beyond/momentours/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     RANDOMQUES_ANSWER_FAILURE(40018, HttpStatus.UNAUTHORIZED, "랜덤질문 답변 등록에 실패했습니다."), // 블랙리스트 등록 실패
     QUES_ANSWER_UPDATE_FAILURE(40019, HttpStatus.UNAUTHORIZED, "랜덤질문 답변 수정에 실패했습니다."), // 랜덤질문 답변 수정 실패
     QUES_ANSWER_DELETE_FAILURE(40020, HttpStatus.UNAUTHORIZED, "랜덤질문 답변 삭제에 실패했습니다."), // 랜덤질문 답변 삭제 실패
+    EMAIL_ALREADY_EXISTS(40021, HttpStatus.UNAUTHORIZED, "이미 존재하는 이메일입니다."),
 
     // 403: 권한 부족 (Forbidden)
 

--- a/src/main/java/beyond/momentours/member/command/application/service/MailServiceImpl.java
+++ b/src/main/java/beyond/momentours/member/command/application/service/MailServiceImpl.java
@@ -34,25 +34,9 @@ public class MailServiceImpl implements MailService {
         Random random = new Random();
         StringBuffer key = new StringBuffer();
 
-        for(int i = 0; i < 8; i++) {    // 총 8자리 인증 번호 생성
-            int idx = random.nextInt(3); // 0~2 사이의 값을 랜덤하게 받아와 idx에 집어넣는다.
-
-            // 0,1,2 값을 switchcase를 통해 꼬아버린다.
-            // 숫자와 아스키코드를 이용한다.
-            switch (idx) {
-                case 0 :
-                    // 0일 때, a~z 까지 랜덤 생성 후 key에 추가
-                    key.append((char) (random.nextInt(26) + 97));
-                    break;
-                case 1 :
-                    // 1일 때, A~Z 까지 랜덤 생성 후 key에 추가
-                    key.append((char) (random.nextInt(26) + 65));
-                    break;
-                case 2 :
-                    // 2일 때, 0~9 까지 랜덤 생성 후 key에 추가
-                    key.append((char) (random.nextInt(9)));
-                    break;
-            }
+        for (int i = 0; i < 4; i++) {    // 4자리 인증 번호 생성
+            // 0~9 사이의 값을 랜덤하게 받아와 key에 추가
+            key.append(random.nextInt(10));  // 0부터 9까지의 숫자를 랜덤하게 생성
         }
         code = key.toString();
     }

--- a/src/main/java/beyond/momentours/member/command/application/service/MemberServiceImpl.java
+++ b/src/main/java/beyond/momentours/member/command/application/service/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import beyond.momentours.member.command.application.dto.MemberDTO;
 import beyond.momentours.member.command.application.mapper.MemberConverter;
 import beyond.momentours.member.command.domain.aggregate.entity.Member;
 import beyond.momentours.member.command.domain.repository.MemberRepository;
+import beyond.momentours.member.query.service.MemberQueryService;
 import beyond.momentours.security.JWTUtil;
 import beyond.momentours.util.RedisEmailAuthentication;
 import beyond.momentours.util.SecurityUtil;
@@ -31,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberConverter memberConverter;
+    private final MemberQueryService memberQueryService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final MailService mailService;
     private final RedisEmailAuthentication redisEmailAuthentication;
@@ -38,9 +40,10 @@ public class MemberServiceImpl implements MemberService {
     private final JWTUtil jwtUtil;
 
     @Autowired
-    public MemberServiceImpl(MemberRepository memberRepository, MemberConverter memberConverter, BCryptPasswordEncoder bCryptPasswordEncoder, MailService mailService, RedisEmailAuthentication redisEmailAuthentication, RedisTemplate<String, String> redisTemplate, JWTUtil jwtUtil) {
+    public MemberServiceImpl(MemberRepository memberRepository, MemberConverter memberConverter, MemberQueryService memberQueryService, BCryptPasswordEncoder bCryptPasswordEncoder, MailService mailService, RedisEmailAuthentication redisEmailAuthentication, RedisTemplate<String, String> redisTemplate, JWTUtil jwtUtil) {
         this.memberRepository = memberRepository;
         this.memberConverter = memberConverter;
+        this.memberQueryService = memberQueryService;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.mailService = mailService;
         this.redisEmailAuthentication = redisEmailAuthentication;
@@ -51,13 +54,14 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public MemberDTO signup(MemberDTO memberDTO) {
-
+        if (memberQueryService.emailCheck(memberDTO.getMemberEmail())) {
+            throw new CommonException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
         memberDTO.encodedPwd(bCryptPasswordEncoder.encode(memberDTO.getMemberPassword()));
         Member member = memberConverter.fromDTOToEntity(memberDTO);
         memberRepository.save(member);
-        MemberDTO reponseMemberDTO = memberConverter.fromEntityToDTO(member);
 
-        return reponseMemberDTO;
+        return memberConverter.fromEntityToDTO(member);
     }
 
     /* 회원탈퇴 */

--- a/src/main/java/beyond/momentours/member/query/controller/MemberController.java
+++ b/src/main/java/beyond/momentours/member/query/controller/MemberController.java
@@ -67,4 +67,16 @@ public class MemberController {
         }
     }
 
+    /* 닉네임 중복확인 */
+    @GetMapping("check-nickname")
+    public ResponseDTO<?> nicknameCheck(@RequestParam String memberNickname) {
+        boolean checkNickname = memberQueryService.nicknameCheck(memberNickname);
+
+        if (checkNickname) {
+            return ResponseDTO.ok("이미 존재하는 닉네임입니다.");
+        } else {
+            return ResponseDTO.ok("사용할 수 있는 닉네임입니다.");
+        }
+    }
+
 }

--- a/src/main/java/beyond/momentours/member/query/controller/MemberController.java
+++ b/src/main/java/beyond/momentours/member/query/controller/MemberController.java
@@ -40,7 +40,7 @@ public class MemberController {
     }
 
     /* 회원정보 조회 */
-    @GetMapping("/mypage")
+    @GetMapping("mypage")
     public ResponseDTO<?> getMypage(@AuthenticationPrincipal CustomUserDetails user) {
         MemberDTO memberDTO = memberQueryService.findMemberEmailByMypage(user);
         ResponseMypageVO response = memberQueryConverter.fromDtoToMypageVO(memberDTO);
@@ -53,6 +53,18 @@ public class MemberController {
                                                                @RequestParam(required = false) String memberEmail) {
         List<ResponseMemberSearchVO> response = memberQueryService.getMemberSearch(memberNickname, memberEmail);
         return ResponseDTO.ok(response);
+    }
+
+    /* 이메일 중복확인 */
+    @GetMapping("check-email")
+    public ResponseDTO<?> emailCheck(@RequestParam String memberEmail) {
+        boolean checkEmail = memberQueryService.emailCheck(memberEmail);
+
+        if (checkEmail) {
+            return ResponseDTO.ok("이미 존재하는 이메일입니다.");
+        } else {
+            return ResponseDTO.ok("사용할 수 있는 이메일입니다.");
+        }
     }
 
 }

--- a/src/main/java/beyond/momentours/member/query/repository/MemberMapper.java
+++ b/src/main/java/beyond/momentours/member/query/repository/MemberMapper.java
@@ -18,4 +18,6 @@ public interface MemberMapper {
 
     List<ResponseMemberSearchVO> findMemberSearch(@Param("memberNickname") String memberNickname,
                                                   @Param("memberEmail") String memberEmail);
+
+    String findByMemberNickname(String memberNickname);
 }

--- a/src/main/java/beyond/momentours/member/query/service/MemberQueryService.java
+++ b/src/main/java/beyond/momentours/member/query/service/MemberQueryService.java
@@ -15,4 +15,6 @@ public interface MemberQueryService {
     MemberDTO findMemberEmailByMypage(CustomUserDetails user);
 
     List<ResponseMemberSearchVO> getMemberSearch(String memberNickname, String memberEmail);
+
+    boolean emailCheck(String memberEmail);
 }

--- a/src/main/java/beyond/momentours/member/query/service/MemberQueryService.java
+++ b/src/main/java/beyond/momentours/member/query/service/MemberQueryService.java
@@ -17,4 +17,6 @@ public interface MemberQueryService {
     List<ResponseMemberSearchVO> getMemberSearch(String memberNickname, String memberEmail);
 
     boolean emailCheck(String memberEmail);
+
+    boolean nicknameCheck(String memberNickname);
 }

--- a/src/main/java/beyond/momentours/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/member/query/service/MemberQueryServiceImpl.java
@@ -61,4 +61,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         }
         return response;
     }
+
+    @Override
+    public boolean emailCheck(String memberEmail) {
+        String email = memberMapper.findByMemberEmail(memberEmail);
+        return email != null;
+    }
+
 }

--- a/src/main/java/beyond/momentours/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/member/query/service/MemberQueryServiceImpl.java
@@ -68,4 +68,10 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         return email != null;
     }
 
+    @Override
+    public boolean nicknameCheck(String memberNickname) {
+        String nickname = memberMapper.findByMemberNickname(memberNickname);
+        return nickname != null;
+    }
+
 }

--- a/src/main/resources/beyond/momentours/mapper/member/MemberMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/member/MemberMapper.xml
@@ -66,4 +66,11 @@
             </trim>
     </select>
 
+    <select id="findByMemberNickname" resultType="string" parameterType="string">
+        SELECT
+               a.member_nickname
+          FROM tb_member a
+         WHERE a.member_nickname = #{memberNickname}
+    </select>
+
 </mapper>

--- a/src/main/resources/beyond/momentours/mapper/member/MemberMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/member/MemberMapper.xml
@@ -52,7 +52,7 @@
 
     <select id="findMemberSearch" resultMap="memberResultMap">
         SELECT
-               a.member_email
+               a.member_email,
                a.member_nickname
           FROM tb_member a
          WHERE


### PR DESCRIPTION
#92 #93

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
 1. 회원가입 시 이메일과 닉네임 중복확인 기능 구현
 2. 이메일 인증번호 기존에는 영문, 숫자 랜덤이었는데 UI/UX에 맞춰 숫자 4자리로 수정

  <br/>



  <br/>
