### PR TITLE
feat: 비정규화를 통해 좋아요 엔터티 분리, 좋아요 등록, 삭제 시 분산 락, Redis를 사용한 동시성 문제 고려 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
 
     implementation 'org.locationtech.jts:jts-core:1.19.0'
     implementation 'ch.hsr:geohash:1.4.0'
+
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
 }
 
 test {

--- a/src/main/java/beyond/momentours/comment/query/service/CommentQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/comment/query/service/CommentQueryServiceImpl.java
@@ -7,7 +7,6 @@ import beyond.momentours.comment.query.repository.CommentMapper;
 import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.common.exception.ErrorCode;
 import beyond.momentours.moment.command.domain.aggregate.repository.MomentRepository;
-import beyond.momentours.randomquestion.query.dto.UserRandomQuestionDTO;
 import beyond.momentours.randomquestion.query.repository.RandomQuestionMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/beyond/momentours/config/RedissonConfig.java
+++ b/src/main/java/beyond/momentours/config/RedissonConfig.java
@@ -1,0 +1,17 @@
+package beyond.momentours.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://localhost:6379");
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/beyond/momentours/date_course/command/domain/repository/DateCourseRepository.java
+++ b/src/main/java/beyond/momentours/date_course/command/domain/repository/DateCourseRepository.java
@@ -17,4 +17,10 @@ public interface DateCourseRepository extends JpaRepository<DateCourse, Long> {
             "SET dc.folderId = null " +
             "WHERE dc.folderId = :folderId")
     void clearFolderByFolderId(@Param("folderId") Long folderId);
+
+    @Modifying
+    @Query("UPDATE Moment m " +
+            "  SET m.momentLike = :likeCount " +
+            "WHERE m.momentId = :targetId")
+    void updateLikeCount(@Param("targetId") Long targetId, @Param("likeCount") Long likeCount);
 }

--- a/src/main/java/beyond/momentours/like/command/application/controller/LikeCommandController.java
+++ b/src/main/java/beyond/momentours/like/command/application/controller/LikeCommandController.java
@@ -1,0 +1,34 @@
+package beyond.momentours.like.command.application.controller;
+
+import beyond.momentours.common.ResponseDTO;
+import beyond.momentours.like.command.application.service.LikeCommandService;
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/like")
+@RequiredArgsConstructor
+public class LikeCommandController {
+
+    private final LikeCommandService likeCommandService;
+
+    @PostMapping
+    public ResponseDTO<?> like(@RequestParam LikeType type, @RequestParam Long targetId, @AuthenticationPrincipal CustomUserDetails user) {
+        likeCommandService.like(user.getMember().getMemberId(), type, targetId);
+        return ResponseDTO.ok("좋아요 완료");
+    }
+
+    @DeleteMapping
+    public ResponseDTO<?> unlike(@RequestParam LikeType type, @RequestParam Long targetId, @AuthenticationPrincipal CustomUserDetails user) {
+        likeCommandService.unlike(user.getMember().getMemberId(), type, targetId);
+        return ResponseDTO.ok("좋아요 취소 완료");
+    }
+
+    @GetMapping("/count")
+    public ResponseDTO<Long> getLikeCount(@RequestParam LikeType type, @RequestParam Long targetId) {
+        return ResponseDTO.ok(likeCommandService.getLikeCount(type, targetId));
+    }
+}

--- a/src/main/java/beyond/momentours/like/command/application/service/LikeCommandService.java
+++ b/src/main/java/beyond/momentours/like/command/application/service/LikeCommandService.java
@@ -1,0 +1,14 @@
+package beyond.momentours.like.command.application.service;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import jakarta.transaction.Transactional;
+
+public interface LikeCommandService {
+    @Transactional
+    void like(Long memberId, LikeType type, Long targetId);
+
+    @Transactional
+    void unlike(Long memberId, LikeType type, Long targetId);
+
+    Long getLikeCount(LikeType type, Long targetId);
+}

--- a/src/main/java/beyond/momentours/like/command/application/service/LikeCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/like/command/application/service/LikeCommandServiceImpl.java
@@ -1,8 +1,10 @@
 package beyond.momentours.like.command.application.service;
 
+import beyond.momentours.date_course.query.repository.DateCourseMapper;
 import beyond.momentours.like.command.domain.aggregate.LikeType;
 import beyond.momentours.like.command.domain.aggregate.entity.Like;
 import beyond.momentours.like.command.domain.repository.LikeRepository;
+import beyond.momentours.moment.query.repository.MomentMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
@@ -10,6 +12,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -18,8 +21,11 @@ public class LikeCommandServiceImpl implements LikeCommandService {
 
     private final LikeRepository likeRepository;
     private final RedisTemplate<String, String> redisTemplate;
-    private static final String REDIS_LIKE_COUNT_PREFIX = "like::count::";
     private final RedissonClient redissonClient;
+    private final MomentMapper momentMapper;
+    private final DateCourseMapper dateCourseMapper;
+
+    private static final String REDIS_LIKE_COUNT_PREFIX = "like::count::";
 
     @Transactional
     @Override
@@ -29,16 +35,15 @@ public class LikeCommandServiceImpl implements LikeCommandService {
 
         try {
             if (lock.tryLock(2, 1, TimeUnit.SECONDS)) {
-                if (likeRepository.existsByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId)) {
-                    throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
-                }
+                if (type == LikeType.MOMENT && !momentMapper.existsActiveById(targetId)) throw new IllegalStateException("이미 삭제된 추억입니다.");
+                if (type == LikeType.DATE_COURSE && !dateCourseMapper.existsActiveById(targetId)) throw new IllegalStateException("이미 삭제된 데이트 코스입니다.");
+                if (likeRepository.existsByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId))  throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
 
                 likeRepository.save(Like.builder()
                         .memberId(memberId)
                         .likeType(type)
                         .targetId(targetId)
-                        .build()
-                );
+                        .build());
 
                 String key = REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId;
                 redisTemplate.opsForValue().increment(key);
@@ -63,6 +68,9 @@ public class LikeCommandServiceImpl implements LikeCommandService {
 
         try {
             if (lock.tryLock(2, 1, TimeUnit.SECONDS)) {
+                if (type == LikeType.MOMENT && !momentMapper.existsActiveById(targetId)) throw new IllegalStateException("이미 삭제된 추억입니다.");
+                if (type == LikeType.DATE_COURSE && !dateCourseMapper.existsActiveById(targetId)) throw new IllegalStateException("이미 삭제된 데이트 코스입니다.");
+
                 likeRepository.deleteByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId);
                 redisTemplate.opsForValue().decrement(REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId);
             } else {
@@ -86,7 +94,7 @@ public class LikeCommandServiceImpl implements LikeCommandService {
         if (cached != null) return Long.parseLong(cached);
 
         Long count = likeRepository.countByLikeTypeAndTargetId(type, targetId);
-        redisTemplate.opsForValue().set(key, String.valueOf(count));
+        redisTemplate.opsForValue().set(key, String.valueOf(count), Duration.ofMinutes(1));
         return count;
     }
 }

--- a/src/main/java/beyond/momentours/like/command/application/service/LikeCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/like/command/application/service/LikeCommandServiceImpl.java
@@ -1,0 +1,92 @@
+package beyond.momentours.like.command.application.service;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.like.command.domain.aggregate.entity.Like;
+import beyond.momentours.like.command.domain.repository.LikeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class LikeCommandServiceImpl implements LikeCommandService {
+
+    private final LikeRepository likeRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String REDIS_LIKE_COUNT_PREFIX = "like::count::";
+    private final RedissonClient redissonClient;
+
+    @Transactional
+    @Override
+    public void like(Long memberId, LikeType type, Long targetId) {
+        String lockKey = "lock::like::" + type + "::" + targetId + "::" + memberId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (lock.tryLock(2, 1, TimeUnit.SECONDS)) {
+                if (likeRepository.existsByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId)) {
+                    throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+                }
+
+                likeRepository.save(Like.builder()
+                        .memberId(memberId)
+                        .likeType(type)
+                        .targetId(targetId)
+                        .build()
+                );
+
+                String key = REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId;
+                redisTemplate.opsForValue().increment(key);
+            } else {
+                throw new RuntimeException("잠시 후 다시 시도해주세요.");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("락 획득 실패", e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Transactional
+    @Override
+    public void unlike(Long memberId, LikeType type, Long targetId) {
+        String lockKey = "lock::like::" + type + "::" + targetId + "::" + memberId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (lock.tryLock(2, 1, TimeUnit.SECONDS)) {
+                likeRepository.deleteByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId);
+                redisTemplate.opsForValue().decrement(REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId);
+            } else {
+                throw new RuntimeException("잠시 후 다시 시도해주세요.");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("락 획득 실패", e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public Long getLikeCount(LikeType type, Long targetId) {
+        String key = REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId;
+        String cached = redisTemplate.opsForValue().get(key);
+
+        if (cached != null) return Long.parseLong(cached);
+
+        Long count = likeRepository.countByLikeTypeAndTargetId(type, targetId);
+        redisTemplate.opsForValue().set(key, String.valueOf(count));
+        return count;
+    }
+}

--- a/src/main/java/beyond/momentours/like/command/domain/aggregate/LikeType.java
+++ b/src/main/java/beyond/momentours/like/command/domain/aggregate/LikeType.java
@@ -1,0 +1,18 @@
+package beyond.momentours.like.command.domain.aggregate;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum LikeType {
+
+    MOMENT("MOMENT"),
+    DATE_COURSE("DATE_COURSE");
+
+    private final String likeType;
+
+    LikeType(String likeType) { this.likeType = likeType; }
+
+    @JsonValue
+    public String getType() {
+        return likeType;
+    }
+}

--- a/src/main/java/beyond/momentours/like/command/domain/aggregate/entity/Like.java
+++ b/src/main/java/beyond/momentours/like/command/domain/aggregate/entity/Like.java
@@ -1,0 +1,39 @@
+package beyond.momentours.like.command.domain.aggregate.entity;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_like")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long likeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "like_type", nullable = false)
+    private LikeType likeType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @PrePersist
+    private void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/beyond/momentours/like/command/domain/repository/LikeRepository.java
+++ b/src/main/java/beyond/momentours/like/command/domain/repository/LikeRepository.java
@@ -1,0 +1,13 @@
+package beyond.momentours.like.command.domain.repository;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.like.command.domain.aggregate.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    boolean existsByMemberIdAndLikeTypeAndTargetId(Long memberId, LikeType likeType, Long targetId);
+    void deleteByMemberIdAndLikeTypeAndTargetId(Long memberId, LikeType likeType, Long targetId);
+    Long countByLikeTypeAndTargetId(LikeType likeType, Long targetId);
+}

--- a/src/main/java/beyond/momentours/like/query/controller/LikeQueryController.java
+++ b/src/main/java/beyond/momentours/like/query/controller/LikeQueryController.java
@@ -1,0 +1,27 @@
+package beyond.momentours.like.query.controller;
+
+import beyond.momentours.common.ResponseDTO;
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.like.query.service.LikeQueryService;
+import beyond.momentours.member.command.application.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/like")
+@RequiredArgsConstructor
+public class LikeQueryController {
+
+    private final LikeQueryService likeQueryService;
+
+    @GetMapping("/exists")
+    public ResponseDTO<Boolean> hasUserLiked(@RequestParam LikeType type, @RequestParam Long targetId, @AuthenticationPrincipal CustomUserDetails user) {
+        boolean liked = likeQueryService.hasUserLiked(user.getMember().getMemberId(), type, targetId);
+        return ResponseDTO.ok(liked);
+    }
+
+}

--- a/src/main/java/beyond/momentours/like/query/mapper/LikeMapper.java
+++ b/src/main/java/beyond/momentours/like/query/mapper/LikeMapper.java
@@ -1,0 +1,12 @@
+package beyond.momentours.like.query.mapper;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface LikeMapper {
+
+    boolean existsByMemberAndTarget(@Param("memberId") Long memberId, @Param("type") LikeType type, @Param("targetId") Long targetId);
+
+}

--- a/src/main/java/beyond/momentours/like/query/repository/LikeMapper.java
+++ b/src/main/java/beyond/momentours/like/query/repository/LikeMapper.java
@@ -1,4 +1,4 @@
-package beyond.momentours.like.query.mapper;
+package beyond.momentours.like.query.repository;
 
 import beyond.momentours.like.command.domain.aggregate.LikeType;
 import org.apache.ibatis.annotations.Mapper;

--- a/src/main/java/beyond/momentours/like/query/service/LikeQueryService.java
+++ b/src/main/java/beyond/momentours/like/query/service/LikeQueryService.java
@@ -1,0 +1,7 @@
+package beyond.momentours.like.query.service;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+
+public interface LikeQueryService {
+    boolean hasUserLiked(Long memberId, LikeType type, Long targetId);
+}

--- a/src/main/java/beyond/momentours/like/query/service/LikeQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/like/query/service/LikeQueryServiceImpl.java
@@ -1,7 +1,7 @@
 package beyond.momentours.like.query.service;
 
 import beyond.momentours.like.command.domain.aggregate.LikeType;
-import beyond.momentours.like.query.mapper.LikeMapper;
+import beyond.momentours.like.query.repository.LikeMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/beyond/momentours/like/query/service/LikeQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/like/query/service/LikeQueryServiceImpl.java
@@ -1,0 +1,18 @@
+package beyond.momentours.like.query.service;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.like.query.mapper.LikeMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeQueryServiceImpl implements LikeQueryService {
+
+    private final LikeMapper likeMapper;
+
+    @Override
+    public boolean hasUserLiked(Long memberId, LikeType type, Long targetId) {
+        return likeMapper.existsByMemberAndTarget(memberId, type, targetId);
+    }
+}

--- a/src/main/java/beyond/momentours/like/scheduler/LikeCountSyncScheduler.java
+++ b/src/main/java/beyond/momentours/like/scheduler/LikeCountSyncScheduler.java
@@ -4,12 +4,14 @@ import beyond.momentours.date_course.command.domain.repository.DateCourseReposit
 import beyond.momentours.moment.command.domain.aggregate.repository.MomentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @Slf4j
@@ -19,8 +21,10 @@ public class LikeCountSyncScheduler {
     private final RedisTemplate<String, String> redisTemplate;
     private final MomentRepository momentRepository;
     private final DateCourseRepository dateCourseRepository;
+    private final RedissonClient redissonClient;
 
     private static final String PREFIX = "like::count::";
+    private static final String RETRY_PREFIX = "like::retry::";
 
     @Scheduled(fixedRate = 5 * 60 * 1000)
     public void syncLikeCounts() {
@@ -30,25 +34,73 @@ public class LikeCountSyncScheduler {
         if (keys == null || keys.isEmpty()) return;
 
         for (String key : keys) {
-            String[] parts = key.split("::");
-            if (parts.length != 4) continue;
+            RLock lock = redissonClient.getLock("lock::sync::" + key);
+            try {
+                if (!lock.tryLock(2, 1, TimeUnit.SECONDS)) continue;
 
-            String typeStr = parts[2];
-            Long targetId = Long.parseLong(parts[3]);
-            Long likeCount = Long.parseLong(redisTemplate.opsForValue().get(key));
+                String[] parts = key.split("::");
+                if (parts.length != 4) continue;
 
-            switch (typeStr) {
-                case "MOMENT" -> {
-                    momentRepository.updateLikeCount(targetId, likeCount);
+                String typeStr = parts[2];
+                Long targetId = Long.parseLong(parts[3]);
+                String value = redisTemplate.opsForValue().get(key);
+                if (value == null) continue;
+
+                Long likeCount = Long.parseLong(value);
+
+                switch (typeStr) {
+                    case "MOMENT" -> momentRepository.updateLikeCount(targetId, likeCount);
+                    case "DATE_COURSE" -> dateCourseRepository.updateLikeCount(targetId, likeCount);
+                    default -> throw new IllegalStateException("Unknown type: " + typeStr);
                 }
-                case "DATE_COURSE" -> {
-                    dateCourseRepository.updateLikeCount(targetId, likeCount);
-                }
+
+                redisTemplate.delete(key);
+            } catch (Exception e) {
+                log.error("❌ 좋아요 동기화 실패 - key: {}", key, e);
+
+                String retryKey = RETRY_PREFIX + key.substring(PREFIX.length());
+                redisTemplate.opsForValue().set(retryKey, redisTemplate.opsForValue().get(key));
+            } finally {
+                if (lock.isHeldByCurrentThread()) lock.unlock();
             }
-
-            redisTemplate.expire(key, Duration.ofHours(24));
         }
 
         log.info("✅ 좋아요 동기화 완료");
+    }
+
+    @Scheduled(fixedRate = 1 * 60 * 1000)
+    public void retryFailedSyncs() {
+        Set<String> retryKeys = redisTemplate.keys(RETRY_PREFIX + "*");
+        if (retryKeys == null || retryKeys.isEmpty()) return;
+
+        for (String retryKey : retryKeys) {
+            String key = retryKey.replace(RETRY_PREFIX, PREFIX);
+            RLock lock = redissonClient.getLock("lock::sync::retry::" + key);
+            try {
+                if (!lock.tryLock(2, 1, TimeUnit.SECONDS)) continue;
+
+                String[] parts = key.split("::");
+                if (parts.length != 4) continue;
+
+                String typeStr = parts[2];
+                Long targetId = Long.parseLong(parts[3]);
+                String value = redisTemplate.opsForValue().get(retryKey);
+                if (value == null) continue;
+
+                Long likeCount = Long.parseLong(value);
+
+                switch (typeStr) {
+                    case "MOMENT" -> momentRepository.updateLikeCount(targetId, likeCount);
+                    case "DATE_COURSE" -> dateCourseRepository.updateLikeCount(targetId, likeCount);
+                    default -> throw new IllegalStateException("Unknown type: " + typeStr);
+                }
+
+                redisTemplate.delete(retryKey);
+            } catch (Exception e) {
+                log.error("❌ 재시도 동기화 실패 - retryKey: {}", retryKey, e);
+            } finally {
+                if (lock.isHeldByCurrentThread()) lock.unlock();
+            }
+        }
     }
 }

--- a/src/main/java/beyond/momentours/like/scheduler/LikeCountSyncScheduler.java
+++ b/src/main/java/beyond/momentours/like/scheduler/LikeCountSyncScheduler.java
@@ -1,0 +1,54 @@
+package beyond.momentours.like.scheduler;
+
+import beyond.momentours.date_course.command.domain.repository.DateCourseRepository;
+import beyond.momentours.moment.command.domain.aggregate.repository.MomentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Set;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LikeCountSyncScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final MomentRepository momentRepository;
+    private final DateCourseRepository dateCourseRepository;
+
+    private static final String PREFIX = "like::count::";
+
+    @Scheduled(fixedRate = 5 * 60 * 1000)
+    public void syncLikeCounts() {
+        log.info("좋아요 Redis DB 동기화 시작");
+
+        Set<String> keys = redisTemplate.keys(PREFIX + "*");
+        if (keys == null || keys.isEmpty()) return;
+
+        for (String key : keys) {
+            String[] parts = key.split("::");
+            if (parts.length != 4) continue;
+
+            String typeStr = parts[2];
+            Long targetId = Long.parseLong(parts[3]);
+            Long likeCount = Long.parseLong(redisTemplate.opsForValue().get(key));
+
+            switch (typeStr) {
+                case "MOMENT" -> {
+                    momentRepository.updateLikeCount(targetId, likeCount);
+                }
+                case "DATE_COURSE" -> {
+                    dateCourseRepository.updateLikeCount(targetId, likeCount);
+                }
+            }
+
+            redisTemplate.expire(key, Duration.ofHours(24));
+        }
+
+        log.info("✅ 좋아요 동기화 완료");
+    }
+}

--- a/src/main/java/beyond/momentours/moment/command/domain/aggregate/repository/MomentRepository.java
+++ b/src/main/java/beyond/momentours/moment/command/domain/aggregate/repository/MomentRepository.java
@@ -1,9 +1,18 @@
 package beyond.momentours.moment.command.domain.aggregate.repository;
 
 import beyond.momentours.moment.command.domain.aggregate.entity.Moment;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MomentRepository extends JpaRepository<Moment, Long> {
+    @Modifying
+    @Query("UPDATE Moment m " +
+            "  SET m.momentLike = :likeCount " +
+            "WHERE m.momentId = :targetId")
+    void updateLikeCount(@Param("targetId") Long targetId, @Param("likeCount") Long likeCount);
+
 }

--- a/src/main/java/beyond/momentours/moment/query/repository/MomentMapper.java
+++ b/src/main/java/beyond/momentours/moment/query/repository/MomentMapper.java
@@ -12,4 +12,7 @@ public interface MomentMapper {
     ResponseMomentDetailVO findMomentDetailById(@Param("momentId") Long momentId);
 
     List<ResponseMomentListItemVO> findMomentsByLocationIdWithFilter(Long locationId, Long cursor, int size, String sort, Boolean onlyMine, Boolean certifiedOnly, Long memberId);
+
+    boolean existsActiveById(@Param("momentId") Long momentId);
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,3 +72,8 @@ mybatis:
 #      static: ap-northeast-2
 #    s3:
 #      bucket: momentours-dev-folder
+
+redisson:
+  config: |
+    singleServerConfig:
+      address: "redis://localhost:6379"

--- a/src/main/resources/beyond/momentours/mapper/like/LikeMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/like/LikeMapper.xml
@@ -3,7 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="beyond.momentours.like.query.mapper.LikeMapper">
+<mapper namespace="beyond.momentours.like.query.repository.LikeMapper">
 
     <select id="existsByMemberAndTarget" resultType="boolean">
         SELECT EXISTS (

--- a/src/main/resources/beyond/momentours/mapper/like/LikeMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/like/LikeMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="beyond.momentours.like.query.mapper.LikeMapper">
+
+    <select id="existsByMemberAndTarget" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+              FROM tb_like
+             WHERE member_id = #{memberId}
+               AND like_type = #{type}
+               AND target_id = #{targetId}
+        )
+    </select>
+
+</mapper>

--- a/src/main/resources/beyond/momentours/mapper/moment/MomentMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/moment/MomentMapper.xml
@@ -40,4 +40,13 @@
            AND m.moment_status = true
     </select>
 
+    <select id="existsActiveById" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+              FROM tb_moment
+             WHERE moment_id = #{momentId}
+               AND moment_status = true
+        )
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
1. 유저가 좋아요를 누르면
- Redis에서 해당 콘텐츠 ID의 like count를 증가 (INCR) (혹은 단순히 해당 유저의 좋아요 여부만 Redis에 저장하고, 별도 스케줄러로 5분마다 count 처리)

2. DB에는 일정 주기로 batch update
- 예: 5분마다 Redis → DB로 sync

3. 사용자에게 보여줄 때는 -> DB에서 가져온 count + Redis에 있는 증가분을 더해서 표시

<추가>
- 동기화 실패 시 retry 키에 저장하여 재시도 수행

참고자료
- [https://ppaksang.tistory.com/26](https://ppaksang.tistory.com/26)

  <br/>
