### PR TITLE
feat: 좋아요 기능 (redis, redisson, kafka 활용) 고도화, 장소 검색 시 클러스터링 조회 및 상세 조회, 추억 관련 api 메서드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,13 @@ dependencies {
     implementation 'ch.hsr:geohash:1.4.0'
 
     implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
+
+    // 좋아요 기능 Redis 죽는 것을 대비하기 위해 kafka 적용
+    implementation 'org.springframework.kafka:spring-kafka'
+}
+
+configurations.all {
+    exclude group: 'commons-logging', module: 'commons-logging'
 }
 
 test {

--- a/src/main/java/beyond/momentours/config/KafkaConfig.java
+++ b/src/main/java/beyond/momentours/config/KafkaConfig.java
@@ -1,0 +1,34 @@
+package beyond.momentours.config;
+
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/beyond/momentours/like/command/application/controller/LikeCommandController.java
+++ b/src/main/java/beyond/momentours/like/command/application/controller/LikeCommandController.java
@@ -3,6 +3,7 @@ package beyond.momentours.like.command.application.controller;
 import beyond.momentours.common.ResponseDTO;
 import beyond.momentours.like.command.application.service.LikeCommandService;
 import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.like.command.domain.dto.LikeRequestDTO;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,8 +17,8 @@ public class LikeCommandController {
     private final LikeCommandService likeCommandService;
 
     @PostMapping
-    public ResponseDTO<?> like(@RequestParam LikeType type, @RequestParam Long targetId, @AuthenticationPrincipal CustomUserDetails user) {
-        likeCommandService.like(user.getMember().getMemberId(), type, targetId);
+    public ResponseDTO<?> like(@RequestBody LikeRequestDTO request, @AuthenticationPrincipal CustomUserDetails user) {
+        likeCommandService.like(user.getMember().getMemberId(), request.getType(), request.getTargetId());
         return ResponseDTO.ok("좋아요 완료");
     }
 

--- a/src/main/java/beyond/momentours/like/command/application/service/LikeCommandService.java
+++ b/src/main/java/beyond/momentours/like/command/application/service/LikeCommandService.java
@@ -1,6 +1,7 @@
 package beyond.momentours.like.command.application.service;
 
 import beyond.momentours.like.command.domain.aggregate.LikeType;
+import beyond.momentours.like.command.domain.dto.LikeEventDto;
 import jakarta.transaction.Transactional;
 
 public interface LikeCommandService {
@@ -11,4 +12,6 @@ public interface LikeCommandService {
     void unlike(Long memberId, LikeType type, Long targetId);
 
     Long getLikeCount(LikeType type, Long targetId);
+
+    void recoverLike(LikeEventDto event);
 }

--- a/src/main/java/beyond/momentours/like/command/application/service/LikeCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/like/command/application/service/LikeCommandServiceImpl.java
@@ -3,18 +3,22 @@ package beyond.momentours.like.command.application.service;
 import beyond.momentours.date_course.query.repository.DateCourseMapper;
 import beyond.momentours.like.command.domain.aggregate.LikeType;
 import beyond.momentours.like.command.domain.aggregate.entity.Like;
+import beyond.momentours.like.command.domain.dto.LikeEventDto;
 import beyond.momentours.like.command.domain.repository.LikeRepository;
 import beyond.momentours.moment.query.repository.MomentMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LikeCommandServiceImpl implements LikeCommandService {
@@ -24,6 +28,7 @@ public class LikeCommandServiceImpl implements LikeCommandService {
     private final RedissonClient redissonClient;
     private final MomentMapper momentMapper;
     private final DateCourseMapper dateCourseMapper;
+    private final LikeEventProducer likeEventProducer;
 
     private static final String REDIS_LIKE_COUNT_PREFIX = "like::count::";
 
@@ -32,12 +37,13 @@ public class LikeCommandServiceImpl implements LikeCommandService {
     public void like(Long memberId, LikeType type, Long targetId) {
         String lockKey = "lock::like::" + type + "::" + targetId + "::" + memberId;
         RLock lock = redissonClient.getLock(lockKey);
+        boolean redisSuccess = false;
 
         try {
             if (lock.tryLock(2, 1, TimeUnit.SECONDS)) {
                 if (type == LikeType.MOMENT && !momentMapper.existsActiveById(targetId)) throw new IllegalStateException("이미 삭제된 추억입니다.");
                 if (type == LikeType.DATE_COURSE && !dateCourseMapper.existsActiveById(targetId)) throw new IllegalStateException("이미 삭제된 데이트 코스입니다.");
-                if (likeRepository.existsByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId))  throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+                if (likeRepository.existsByMemberIdAndLikeTypeAndTargetId(memberId, type, targetId)) throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
 
                 likeRepository.save(Like.builder()
                         .memberId(memberId)
@@ -45,8 +51,8 @@ public class LikeCommandServiceImpl implements LikeCommandService {
                         .targetId(targetId)
                         .build());
 
-                String key = REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId;
-                redisTemplate.opsForValue().increment(key);
+                redisTemplate.opsForValue().increment(REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId);
+                redisSuccess = true;
             } else {
                 throw new RuntimeException("잠시 후 다시 시도해주세요.");
             }
@@ -57,6 +63,19 @@ public class LikeCommandServiceImpl implements LikeCommandService {
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
+        }
+
+        LikeEventDto event = new LikeEventDto(
+                memberId,
+                targetId,
+                type.name(),
+                "LIKE",
+                LocalDateTime.now()
+        );
+        likeEventProducer.sendLikeEvent(event);
+
+        if (!redisSuccess) {
+            log.warn("[Kafka fallback] Redis 증가 실패 - Kafka 처리 예정");
         }
     }
 
@@ -96,5 +115,27 @@ public class LikeCommandServiceImpl implements LikeCommandService {
         Long count = likeRepository.countByLikeTypeAndTargetId(type, targetId);
         redisTemplate.opsForValue().set(key, String.valueOf(count), Duration.ofMinutes(1));
         return count;
+    }
+
+    @Override
+    public void recoverLike(LikeEventDto event) {
+        try {
+            LikeType type = LikeType.valueOf(event.getLikeType());
+            Long targetId = event.getTargetId();
+            String key = REDIS_LIKE_COUNT_PREFIX + type + "::" + targetId;
+
+            if ("LIKE".equals(event.getAction())) {
+                redisTemplate.opsForValue().increment(key);
+                log.info("Kafka 복구 - Redis 좋아요 증가 완료: {}", key);
+            } else if ("UNLIKE".equals(event.getAction())) {
+                redisTemplate.opsForValue().decrement(key);
+                log.info("Kafka 복구 - Redis 좋아요 감소 완료: {}", key);
+            } else {
+                log.warn("Kafka 복구 - 알 수 없는 액션 타입: {}", event.getAction());
+            }
+
+        } catch (Exception e) {
+            log.error("Kafka 복구 중 오류 발생", e);
+        }
     }
 }

--- a/src/main/java/beyond/momentours/like/command/application/service/LikeEventProducer.java
+++ b/src/main/java/beyond/momentours/like/command/application/service/LikeEventProducer.java
@@ -1,0 +1,25 @@
+package beyond.momentours.like.command.application.service;
+
+import beyond.momentours.like.command.domain.dto.LikeEventDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeEventProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void sendLikeEvent(LikeEventDto event) {
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send("like-events", message);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Kafka 메시지 직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/beyond/momentours/like/command/domain/dto/LikeEventDto.java
+++ b/src/main/java/beyond/momentours/like/command/domain/dto/LikeEventDto.java
@@ -1,0 +1,17 @@
+package beyond.momentours.like.command.domain.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeEventDto {
+    private Long memberId;
+    private Long targetId;
+    private String likeType;
+    private String action;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/beyond/momentours/like/command/domain/dto/LikeRequestDTO.java
+++ b/src/main/java/beyond/momentours/like/command/domain/dto/LikeRequestDTO.java
@@ -1,0 +1,16 @@
+package beyond.momentours.like.command.domain.dto;
+
+import beyond.momentours.like.command.domain.aggregate.LikeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeRequestDTO {
+    private LikeType type;
+    private Long targetId;
+}

--- a/src/main/java/beyond/momentours/like/command/domain/repository/LikeRepository.java
+++ b/src/main/java/beyond/momentours/like/command/domain/repository/LikeRepository.java
@@ -2,12 +2,17 @@ package beyond.momentours.like.command.domain.repository;
 
 import beyond.momentours.like.command.domain.aggregate.LikeType;
 import beyond.momentours.like.command.domain.aggregate.entity.Like;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByMemberIdAndLikeTypeAndTargetId(Long memberId, LikeType likeType, Long targetId);
+
+    @Modifying
+    @Transactional
     void deleteByMemberIdAndLikeTypeAndTargetId(Long memberId, LikeType likeType, Long targetId);
     Long countByLikeTypeAndTargetId(LikeType likeType, Long targetId);
 }

--- a/src/main/java/beyond/momentours/like/consumer/kafka/LikeEventConsumer.java
+++ b/src/main/java/beyond/momentours/like/consumer/kafka/LikeEventConsumer.java
@@ -1,0 +1,31 @@
+package beyond.momentours.like.consumer.kafka;
+
+import beyond.momentours.like.command.application.service.LikeCommandService;
+import beyond.momentours.like.command.domain.dto.LikeEventDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeEventConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final LikeCommandService likeCommandService;
+
+    @KafkaListener(topics = "like-events", groupId = "like-consumer")
+    public void handleLikeEvent(String message) {
+        try {
+            LikeEventDto event = objectMapper.readValue(message, LikeEventDto.class);
+            log.info("Kafka 이벤트 수신: {}", event);
+
+            likeCommandService.recoverLike(event);
+
+        } catch (Exception e) {
+            log.error("Kafka 메시지 처리 실패", e);
+        }
+    }
+}

--- a/src/main/java/beyond/momentours/like/scheduler/LikeCountSyncScheduler.java
+++ b/src/main/java/beyond/momentours/like/scheduler/LikeCountSyncScheduler.java
@@ -2,6 +2,7 @@ package beyond.momentours.like.scheduler;
 
 import beyond.momentours.date_course.command.domain.repository.DateCourseRepository;
 import beyond.momentours.moment.command.domain.aggregate.repository.MomentRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -26,6 +27,7 @@ public class LikeCountSyncScheduler {
     private static final String PREFIX = "like::count::";
     private static final String RETRY_PREFIX = "like::retry::";
 
+    @Transactional
     @Scheduled(fixedRate = 5 * 60 * 1000)
     public void syncLikeCounts() {
         log.info("좋아요 Redis DB 동기화 시작");
@@ -68,6 +70,7 @@ public class LikeCountSyncScheduler {
         log.info("✅ 좋아요 동기화 완료");
     }
 
+    @Transactional
     @Scheduled(fixedRate = 1 * 60 * 1000)
     public void retryFailedSyncs() {
         Set<String> retryKeys = redisTemplate.keys(RETRY_PREFIX + "*");

--- a/src/main/java/beyond/momentours/location/command/application/dto/LocationDTO.java
+++ b/src/main/java/beyond/momentours/location/command/application/dto/LocationDTO.java
@@ -18,7 +18,12 @@ public class LocationDTO {
     private BigDecimal longitude;
     private String locationName;
     private String address;
+    private String imageUrl;
     private LocationStatus locationStatus;
+    private String description;
+    private Double rating;
+    private Boolean isOpen;
+    private LocalDateTime closingTime;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/beyond/momentours/location/command/application/mapper/LocationConverter.java
+++ b/src/main/java/beyond/momentours/location/command/application/mapper/LocationConverter.java
@@ -11,9 +11,14 @@ public class LocationConverter {
                 .locationId(savedLocation.getLocationId())
                 .locationName(savedLocation.getLocationName())
                 .address(savedLocation.getAddress())
+                .imageUrl(savedLocation.getImageUrls())
                 .latitude(savedLocation.getLatitude())
                 .longitude(savedLocation.getLongitude())
                 .locationStatus(savedLocation.getLocationStatus())
+                .description(savedLocation.getDescription())
+                .rating(savedLocation.getRating())
+                .isOpen(savedLocation.getIsOpen())
+                .closingTime(savedLocation.getClosingTime())
                 .build();
     }
 }

--- a/src/main/java/beyond/momentours/location/command/application/scheduler/LocationSyncScheduler.java
+++ b/src/main/java/beyond/momentours/location/command/application/scheduler/LocationSyncScheduler.java
@@ -1,0 +1,56 @@
+package beyond.momentours.location.command.application.scheduler;
+
+import beyond.momentours.location.command.domain.aggregate.LocationStatus;
+import beyond.momentours.location.command.domain.aggregate.entity.Location;
+import beyond.momentours.location.command.domain.repository.LocationRepository;
+import beyond.momentours.location.query.external.NaverMapSearchClient;
+import beyond.momentours.location.query.external.dto.NaverPlaceDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LocationSyncScheduler {
+
+    private final LocationRepository locationRepository;
+    private final NaverMapSearchClient naverMapSearchClient;
+
+    // 매월 1일 새벽 3시에 실행
+    @Scheduled(cron = "0 0 3 1 * ?")
+    public void syncLocationsWithNaver() {
+        log.info("[장소 동기화] 네이버 지도와 장소 정보 동기화 시작");
+
+        List<Location> locations = locationRepository.findAllByLocationStatus(LocationStatus.UNCHANGED);
+
+        for (Location location : locations) {
+            try {
+                NaverPlaceDTO naverInfo = naverMapSearchClient.searchPlaceFirstMatch(location.getLocationName());
+
+                if (naverInfo == null) {
+                    location.setLocationStatus(LocationStatus.CLOSED);
+                    log.info("폐업 처리: {}", location.getLocationName());
+                } else if (!location.getLatitude().equals(naverInfo.getLatitude()) ||
+                           !location.getLongitude().equals(naverInfo.getLongitude())) {
+                    location.setLocationStatus(LocationStatus.RELOCATION);
+                    log.info("이전 처리: {} (기존: {},{} / 네이버: {},{})",
+                        location.getLocationName(),
+                        location.getLatitude(), location.getLongitude(),
+                        naverInfo.getLatitude(), naverInfo.getLongitude());
+                } else {
+                    location.setAddress(naverInfo.getAddress());
+                    location.setDescription(naverInfo.getDescription());
+                    location.setLocationStatus(LocationStatus.UNCHANGED);
+                }
+                locationRepository.save(location);
+            } catch (Exception e) {
+                log.error("장소 동기화 중 오류: {}", location.getLocationName(), e);
+            }
+        }
+        log.info("[장소 동기화] 네이버 지도와 장소 정보 동기화 완료");
+    }
+} 

--- a/src/main/java/beyond/momentours/location/command/domain/aggregate/entity/Location.java
+++ b/src/main/java/beyond/momentours/location/command/domain/aggregate/entity/Location.java
@@ -7,6 +7,7 @@ import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -28,14 +29,29 @@ public class Location {
     @Column(name = "longitude", precision = 10, scale = 7)
     private BigDecimal longitude;
 
-    @Column(name = "location_name")
+    @Column(name = "location_name", nullable = false)
     private String locationName;
 
-    @Column(name = "address")
+    @Column(name = "address", nullable = false)
     private String address;
 
-    @Column(name = "location_status")
+    @Column(name = "image_urls", nullable = false)
+    private String imageUrls;
+
+    @Column(name = "location_status", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
     private LocationStatus locationStatus;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "rating", precision = 2)
+    private Double rating;
+
+    @Column(name = "is_open")
+    private Boolean isOpen;
+
+    @Column(name = "closing_time")
+    private LocalDateTime closingTime;
 
     @Column(name = "geohash")
     private String geohash;
@@ -48,4 +64,28 @@ public class Location {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public List<String> getImageUrlList() {
+        return imageUrls != null ? List.of(imageUrls.split(",")) : List.of();
+    }
+
+    public void setLocationStatus(beyond.momentours.location.command.domain.aggregate.LocationStatus status) {
+        this.locationStatus = status;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public void setClosingTime(LocalDateTime closingTime) {
+        this.closingTime = closingTime;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setRating(Double rating) {
+        this.rating = rating;
+    }
 }

--- a/src/main/java/beyond/momentours/location/command/domain/repository/LocationRepository.java
+++ b/src/main/java/beyond/momentours/location/command/domain/repository/LocationRepository.java
@@ -1,11 +1,15 @@
 package beyond.momentours.location.command.domain.repository;
 
+import beyond.momentours.location.command.domain.aggregate.LocationStatus;
 import beyond.momentours.location.command.domain.aggregate.entity.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
     Optional<Location> findByLatitudeAndLongitude(BigDecimal latitude, BigDecimal longitude);
+
+    List<Location> findAllByLocationStatus(LocationStatus unchanged);
 }

--- a/src/main/java/beyond/momentours/location/query/controller/LocationQueryController.java
+++ b/src/main/java/beyond/momentours/location/query/controller/LocationQueryController.java
@@ -3,6 +3,7 @@ package beyond.momentours.location.query.controller;
 import beyond.momentours.common.ResponseDTO;
 import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.couple.query.service.QueryCoupleService;
 import beyond.momentours.location.query.external.NaverMapSearchClient;
 import beyond.momentours.location.query.external.dto.NaverPlaceDTO;
 import beyond.momentours.location.query.service.LocationQueryService;
@@ -10,6 +11,7 @@ import beyond.momentours.location.query.vo.*;
 import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import beyond.momentours.moment.common.MomentFilterCondition;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,10 +21,12 @@ import java.util.List;
 @RestController
 @RequestMapping("api/location")
 @RequiredArgsConstructor
+@Slf4j
 public class LocationQueryController {
 
     private final LocationQueryService locationQueryService;
     private final NaverMapSearchClient naverMapSearchClient;
+    private final QueryCoupleService queryCoupleService;
 
     @GetMapping("/map")
     public ResponseDTO<List<ResponseLocationMapVO>> getLocationsOnMap(@RequestParam BigDecimal latitudeMin, @RequestParam BigDecimal latitudeMax, @RequestParam BigDecimal longitudeMin, @RequestParam BigDecimal longitudeMax) {
@@ -30,9 +34,29 @@ public class LocationQueryController {
         return ResponseDTO.ok(result);
     }
 
-    @GetMapping("/cluster")
-    public ResponseDTO<List<ResponseLocationClusterItemVO>> getClusteredLocations(@RequestParam BigDecimal latitude, @RequestParam BigDecimal longitude) {
-        List<ResponseLocationClusterItemVO> result = locationQueryService.getClusteredLocations(latitude, longitude);
+    @GetMapping("/clusters")
+    public ResponseDTO<List<ResponseLocationClusterItemVO>> getClusteredLocations(
+            @RequestParam BigDecimal latitude,
+            @RequestParam BigDecimal longitude,
+            @RequestParam int zoom,
+            @RequestParam BigDecimal latitudeMin,
+            @RequestParam BigDecimal latitudeMax,
+            @RequestParam BigDecimal longitudeMin,
+            @RequestParam BigDecimal longitudeMax
+    ) {
+        List<ResponseLocationClusterItemVO> result = locationQueryService.getClusteredLocationsInBounds(
+                latitude, longitude, zoom, latitudeMin, latitudeMax, longitudeMin, longitudeMax
+        );
+        return ResponseDTO.ok(result);
+    }
+
+    @GetMapping("/cluster/locations")
+    public ResponseDTO<List<ResponseLocationMapVO>> getClusterLocations(
+            @RequestParam BigDecimal latitude,
+            @RequestParam BigDecimal longitude,
+            @RequestParam int zoom
+    ) {
+        List<ResponseLocationMapVO> result = locationQueryService.getClusterLocations(latitude, longitude, zoom);
         return ResponseDTO.ok(result);
     }
 
@@ -42,26 +66,28 @@ public class LocationQueryController {
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "recent") String sort,
-            @RequestParam(required = false) Boolean onlyMine,
+            @RequestParam(required = false) Boolean isOurs,
             @RequestParam(required = false) Boolean certifiedOnly,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         Long memberId = user != null ? user.getMember().getMemberId() : null;
-        MomentFilterCondition condition = getMomentFilterCondition(locationId, cursor, size, sort, onlyMine, certifiedOnly, memberId);
+        Long coupleId = queryCoupleService.getCoupleIdByMemberId(memberId);
+        MomentFilterCondition condition = getMomentFilterCondition(locationId, cursor, size, sort, isOurs, certifiedOnly, memberId, coupleId);
 
         ResponseLocationMomentPageVO result = locationQueryService.getLocationWithMoments(condition);
         return ResponseDTO.ok(result);
     }
 
-    private MomentFilterCondition getMomentFilterCondition(Long locationId, Long cursor, int size, String sort, Boolean onlyMine, Boolean certifiedOnly, Long memberId) {
+    private MomentFilterCondition getMomentFilterCondition(Long locationId, Long cursor, int size, String sort, Boolean ours, Boolean certifiedOnly, Long memberId, Long coupleId) {
         return MomentFilterCondition.builder()
                 .locationId(locationId)
                 .cursor(cursor)
                 .size(size)
                 .sort(sort)
-                .onlyMine(onlyMine)
+                .isOurs(ours)
                 .certifiedOnly(certifiedOnly)
                 .memberId(memberId)
+                .coupleId(coupleId)
                 .build();
     }
 

--- a/src/main/java/beyond/momentours/location/query/external/dto/NaverPlaceDTO.java
+++ b/src/main/java/beyond/momentours/location/query/external/dto/NaverPlaceDTO.java
@@ -15,4 +15,5 @@ public class NaverPlaceDTO {
     private BigDecimal latitude;
     private BigDecimal longitude;
     private String category;
+    private String description;
 }

--- a/src/main/java/beyond/momentours/location/query/repository/LocationMapper.java
+++ b/src/main/java/beyond/momentours/location/query/repository/LocationMapper.java
@@ -19,8 +19,6 @@ public interface LocationMapper {
 
     List<ResponseLocationMapVO> findLocationsInBounds(@Param("latitudeMin") BigDecimal latitudeMin, @Param("latitudeMax") BigDecimal latitudeMax, @Param("longitudeMin") BigDecimal longitudeMin, @Param("longitudeMax") BigDecimal longitudeMax);
 
-    List<ResponseLocationClusterItemVO> findLocationsNearCoordinates(@Param("latitude") BigDecimal latitude, @Param("longitude") BigDecimal longitude);
-
     List<ResponseLocationClusterGroupVO> findGroupedLocationClusters(@Param("round") int round);
 
     List<ResponseLocationSearchVO> findLocationByKeyword(@Param("keyword") String keyword);
@@ -33,4 +31,9 @@ public interface LocationMapper {
 
     ResponseLocationDetailVO getLocationDetail(@Param("locationId") Long locationId);
 
+    List<ResponseLocationClusterItemVO> findClusteredLocationsByZoomLevel(@Param("latRound") int latRound, @Param("lngRound") int lngRound, @Param("latitudeMin") BigDecimal latitudeMin, @Param("latitudeMax") BigDecimal latitudeMax, @Param("longitudeMin") BigDecimal longitudeMin, @Param("longitudeMax") BigDecimal longitudeMax);
+
+    List<ResponseLocationClusterItemVO> findClusteredLocationsByZoomLevelWithLimit(@Param("latRound") int latRound, @Param("lngRound") int lngRound, @Param("latitudeMin") BigDecimal latitudeMin, @Param("latitudeMax") BigDecimal latitudeMax, @Param("longitudeMin") BigDecimal longitudeMin, @Param("longitudeMax") BigDecimal longitudeMax, @Param("limit") int limit);
+
+    List<ResponseLocationMapVO> findLocationsByRoundedCoordinate(@Param("latitude") BigDecimal latitude, @Param("longitude") BigDecimal longitude, @Param("round") int round);
 }

--- a/src/main/java/beyond/momentours/location/query/service/LocationQueryService.java
+++ b/src/main/java/beyond/momentours/location/query/service/LocationQueryService.java
@@ -12,8 +12,6 @@ public interface LocationQueryService {
 
     List<ResponseLocationMapVO> getLocationsInBounds(BigDecimal latitudeMin, BigDecimal latitudeMax, BigDecimal longitudeMin, BigDecimal longitudeMax);
 
-    List<ResponseLocationClusterItemVO> getClusteredLocations(BigDecimal lat, BigDecimal lng);
-
     ResponseLocationMomentPageVO getLocationWithMoments(MomentFilterCondition condition);
 
     List<ResponseLocationClusterGroupVO> getGroupedLocationClustersByZoom(int zoom);
@@ -28,4 +26,7 @@ public interface LocationQueryService {
 
     ResponseLocationDetailVO getLocationDetail(Long locationId);
 
+    List<ResponseLocationClusterItemVO> getClusteredLocationsInBounds(BigDecimal latitude, BigDecimal longitude, int zoom, BigDecimal latitudeMin, BigDecimal latitudeMax, BigDecimal longitudeMin, BigDecimal longitudeMax);
+
+    List<ResponseLocationMapVO> getClusterLocations(BigDecimal latitude, BigDecimal longitude, int zoom);
 }

--- a/src/main/java/beyond/momentours/location/query/service/LocationQueryServiceImpl.java
+++ b/src/main/java/beyond/momentours/location/query/service/LocationQueryServiceImpl.java
@@ -55,19 +55,12 @@ public class LocationQueryServiceImpl implements LocationQueryService {
     }
 
     @Override
-    public List<ResponseLocationClusterItemVO> getClusteredLocations(BigDecimal latitude, BigDecimal longitude) {
-        return locationMapper.findLocationsNearCoordinates(latitude, longitude);
-    }
-
-    @Override
     public ResponseLocationMomentPageVO getLocationWithMoments(MomentFilterCondition condition) {
         Location location = locationMapper.findById(condition.getLocationId());
         if (location == null) throw new CommonException(ErrorCode.NOT_FOUND_LOCATION);
 
-        List<ResponseMomentListItemVO> moments = getMomentsByLocationIdWithFilter(condition);
-
-        Long nextCursor = moments.isEmpty() ? null : moments.get(moments.size() - 1).getMomentId();
-        boolean hasNext = moments.size() == condition.getSize();
+        ResponseMomentCursorListVO ours = getCursorPagedMoments(condition, true);
+        ResponseMomentCursorListVO others = getCursorPagedMoments(condition, false);
 
         return ResponseLocationMomentPageVO.builder()
                 .locationId(location.getLocationId())
@@ -75,11 +68,22 @@ public class LocationQueryServiceImpl implements LocationQueryService {
                 .latitude(location.getLatitude())
                 .longitude(location.getLongitude())
                 .address(location.getAddress())
-                .momentPage(ResponseMomentCursorListVO.builder()
-                        .moments(moments)
-                        .nextCursor(nextCursor)
-                        .hasNext(hasNext)
-                        .build())
+                .description(location.getDescription())
+                .ours(ours)
+                .others(others)
+                .build();
+    }
+
+    private ResponseMomentCursorListVO getCursorPagedMoments(MomentFilterCondition baseCondition, boolean ours) {
+        MomentFilterCondition condition = baseCondition.toBuilder().isOurs(ours).build();
+        List<ResponseMomentListItemVO> list = getMomentsByLocationIdWithFilter(condition);
+        Long nextCursor = list.isEmpty() ? null : list.get(list.size() - 1).getMomentId();
+        boolean hasNext = list.size() == condition.getSize();
+
+        return ResponseMomentCursorListVO.builder()
+                .moments(list)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
                 .build();
     }
 
@@ -89,9 +93,10 @@ public class LocationQueryServiceImpl implements LocationQueryService {
                 condition.getCursor(),
                 condition.getSize(),
                 condition.getSort(),
-                condition.getOnlyMine(),
+                condition.getIsOurs(),
                 condition.getCertifiedOnly(),
-                condition.getMemberId()
+                condition.getMemberId(),
+                condition.getCoupleId()
         );
     }
 
@@ -120,16 +125,13 @@ public class LocationQueryServiceImpl implements LocationQueryService {
                 String category = dto.getCategory();
                 if (category == null || LocationFilterUtil.isExcludedPlace(category)) continue;
 
-                LocationDTO saved = locationCommandService.createLocationWithAddress(
-                        dto.getTitle(), dto.getLatitude(), dto.getLongitude(), dto.getAddress()
-                );
-
                 valid.add(ResponseLocationSearchVO.builder()
-                        .locationId(saved.getLocationId())
-                        .locationName(saved.getLocationName())
-                        .latitude(saved.getLatitude())
-                        .longitude(saved.getLongitude())
-                        .address(saved.getAddress())
+                        .locationId(null)
+                        .locationName(dto.getTitle())
+                        .latitude(dto.getLatitude())
+                        .longitude(dto.getLongitude())
+                        .address(dto.getAddress())
+                        .description(dto.getDescription())
                         .build());
             }
             return valid;
@@ -188,5 +190,44 @@ public class LocationQueryServiceImpl implements LocationQueryService {
         ResponseLocationDetailVO result = locationMapper.getLocationDetail(locationId);
         if (result == null) throw new CommonException(ErrorCode.NOT_FOUND_LOCATION);
         return result;
+    }
+
+    @Override
+    public List<ResponseLocationClusterItemVO> getClusteredLocationsInBounds(
+            BigDecimal latitude, BigDecimal longitude, int zoom,
+            BigDecimal latitudeMin, BigDecimal latitudeMax,
+            BigDecimal longitudeMin, BigDecimal longitudeMax
+    ) {
+        int latRound = getRoundingScale(zoom);
+        int lngRound = getRoundingScale(zoom);
+
+        if (zoom < 13) {
+            return locationMapper.findClusteredLocationsByZoomLevelWithLimit(
+                    latRound, lngRound,
+                    latitudeMin, latitudeMax,
+                    longitudeMin, longitudeMax,
+                    30
+            );
+        } else {
+            return locationMapper.findClusteredLocationsByZoomLevel(
+                    latRound, lngRound,
+                    latitudeMin, latitudeMax,
+                    longitudeMin, longitudeMax
+            );
+        }
+    }
+
+    @Override
+    public List<ResponseLocationMapVO> getClusterLocations(BigDecimal latitude, BigDecimal longitude, int zoom) {
+        int round = getRoundingScale(zoom);
+        return locationMapper.findLocationsByRoundedCoordinate(latitude, longitude, round);
+    }
+
+    private int getRoundingScale(int zoom) {
+        if (zoom >= 16) return 4;
+        else if (zoom >= 14) return 3;
+        else if (zoom >= 12) return 2;
+        else if (zoom >= 10) return 1;
+        else return 0;
     }
 }

--- a/src/main/java/beyond/momentours/location/query/vo/ResponseLocationClusterItemVO.java
+++ b/src/main/java/beyond/momentours/location/query/vo/ResponseLocationClusterItemVO.java
@@ -10,9 +10,11 @@ import java.math.BigDecimal;
 @Builder
 @AllArgsConstructor
 public class ResponseLocationClusterItemVO {
-    private Long locationId;
+    private String locationIds;
+    private String locationId;
     private String locationName;
     private BigDecimal latitude;
     private BigDecimal longitude;
+    private Integer count;
     private Integer momentCount;
 }

--- a/src/main/java/beyond/momentours/location/query/vo/ResponseLocationDetailVO.java
+++ b/src/main/java/beyond/momentours/location/query/vo/ResponseLocationDetailVO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Data
 @Builder
@@ -11,9 +12,15 @@ public class ResponseLocationDetailVO {
     private Long locationId;
     private String locationName;
     private String address;
+    private String images;
+    private String description;
     private BigDecimal latitude;
     private BigDecimal longitude;
     private long momentCount;
     private long totalView;
     private long totalLike;
+
+    public List<String> getImages() {
+        return images == null ? List.of() : List.of(images.split(","));
+    }
 }

--- a/src/main/java/beyond/momentours/location/query/vo/ResponseLocationMapVO.java
+++ b/src/main/java/beyond/momentours/location/query/vo/ResponseLocationMapVO.java
@@ -3,8 +3,11 @@ package beyond.momentours.location.query.vo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -15,4 +18,13 @@ public class ResponseLocationMapVO {
     private BigDecimal latitude;
     private BigDecimal longitude;
     private Integer momentCount;
+    private String description;
+
+    @JsonIgnore
+    private String images;
+
+    public List<String> getImages() {
+        if (images == null || images.isEmpty()) return List.of();
+        return List.of(images.split(","));
+    }
 }

--- a/src/main/java/beyond/momentours/location/query/vo/ResponseLocationMapVO.java
+++ b/src/main/java/beyond/momentours/location/query/vo/ResponseLocationMapVO.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/beyond/momentours/location/query/vo/ResponseLocationMomentPageVO.java
+++ b/src/main/java/beyond/momentours/location/query/vo/ResponseLocationMomentPageVO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 @Builder
@@ -16,5 +17,13 @@ public class ResponseLocationMomentPageVO {
     private BigDecimal latitude;
     private BigDecimal longitude;
     private String address;
-    private ResponseMomentCursorListVO momentPage;
+    private String description;
+    private ResponseMomentCursorListVO ours;
+    private ResponseMomentCursorListVO others;
+
+    private String images;
+
+    public List<String> getImages() {
+        return images == null ? List.of() : List.of(images.split(","));
+    }
 }

--- a/src/main/java/beyond/momentours/location/query/vo/ResponseLocationSearchVO.java
+++ b/src/main/java/beyond/momentours/location/query/vo/ResponseLocationSearchVO.java
@@ -15,4 +15,5 @@ public class ResponseLocationSearchVO {
     private BigDecimal latitude;
     private BigDecimal longitude;
     private String address;
+    private String description;
 }

--- a/src/main/java/beyond/momentours/moment/command/application/controller/MomentCommandController.java
+++ b/src/main/java/beyond/momentours/moment/command/application/controller/MomentCommandController.java
@@ -24,9 +24,8 @@ public class MomentCommandController {
     @PostMapping
     public ResponseDTO<?> createMoment(@RequestBody RequestCreateMomentVO createMomentVO, @AuthenticationPrincipal CustomUserDetails user) {
         log.info("등록 요청 데이터 : {}", createMomentVO);
-        Long memberId = user.getMember().getMemberId();
         MomentDTO momentDTO = momentConverter.fromCreateVOToDTO(createMomentVO);
-        MomentDTO responseMomentDTO = momentCommandService.createMoment(momentDTO, memberId);
+        MomentDTO responseMomentDTO = momentCommandService.createMoment(momentDTO, user);
         return ResponseDTO.ok(momentConverter.fromDTOToCreateVO(responseMomentDTO));
     }
 

--- a/src/main/java/beyond/momentours/moment/command/application/dto/MomentDTO.java
+++ b/src/main/java/beyond/momentours/moment/command/application/dto/MomentDTO.java
@@ -41,6 +41,9 @@ public class MomentDTO {
     @JsonProperty("moment_status")
     private boolean momentStatus;
 
+    @JsonProperty("moment_image_urls")
+    private String momentImageUrls;
+
     @JsonProperty("created_at")
     private LocalDateTime createdAt;
 
@@ -52,6 +55,9 @@ public class MomentDTO {
 
     @JsonProperty("member_id")
     private Long memberId;
+
+    @JsonProperty("couple_id")
+    private Long coupleId;
 
     @JsonProperty("location_name")
     private String locationName;

--- a/src/main/java/beyond/momentours/moment/command/application/service/MomentCommandService.java
+++ b/src/main/java/beyond/momentours/moment/command/application/service/MomentCommandService.java
@@ -4,7 +4,7 @@ import beyond.momentours.member.command.application.dto.CustomUserDetails;
 import beyond.momentours.moment.command.application.dto.MomentDTO;
 
 public interface MomentCommandService {
-    MomentDTO createMoment(MomentDTO momentDTO, Long memberId);
+    MomentDTO createMoment(MomentDTO momentDTO, CustomUserDetails user);
 
     MomentDTO updateMoment(MomentDTO momentDTO, CustomUserDetails user);
 

--- a/src/main/java/beyond/momentours/moment/command/application/service/MomentCommandServiceImpl.java
+++ b/src/main/java/beyond/momentours/moment/command/application/service/MomentCommandServiceImpl.java
@@ -2,6 +2,7 @@ package beyond.momentours.moment.command.application.service;
 
 import beyond.momentours.common.exception.CommonException;
 import beyond.momentours.common.exception.ErrorCode;
+import beyond.momentours.couple.query.service.QueryCoupleService;
 import beyond.momentours.location.command.application.dto.LocationDTO;
 import beyond.momentours.location.command.application.service.LocationCommandService;
 import beyond.momentours.location.query.service.LocationQueryService;
@@ -24,10 +25,11 @@ public class MomentCommandServiceImpl implements MomentCommandService {
     private final LocationCommandService locationCommandService;
     private final LocationQueryService locationQueryService;
     private final MomentConverter momentConverter;
+    private final QueryCoupleService coupleService;
 
     @Transactional
     @Override
-    public MomentDTO createMoment(MomentDTO dto, Long memberId) {
+    public MomentDTO createMoment(MomentDTO dto, CustomUserDetails user) {
         LocationDTO location;
 
         if (dto.getLocationId() != null) {
@@ -38,7 +40,10 @@ public class MomentCommandServiceImpl implements MomentCommandService {
             throw new CommonException(ErrorCode.INVALID_LOCATION_DATA);
         }
 
-        Moment moment = momentConverter.fromDTOToEntity(dto, memberId, location.getLocationId());
+        Long memberId = user.getMember().getMemberId();
+        Long coupleId = coupleService.getCoupleIdByMemberId(memberId);
+
+        Moment moment = momentConverter.fromDTOToEntity(dto, memberId, coupleId, location.getLocationId());
         moment.createMoment();
         Moment saved = momentRepository.save(moment);
         return momentConverter.fromEntityToDTO(saved);

--- a/src/main/java/beyond/momentours/moment/command/domain/aggregate/entity/Moment.java
+++ b/src/main/java/beyond/momentours/moment/command/domain/aggregate/entity/Moment.java
@@ -20,13 +20,13 @@ public class Moment {
     @Column(name = "moment_id")
     private Long momentId;
 
-    @Column(name = "moment_title")
+    @Column(name = "moment_title", nullable = false)
     private String momentTitle;
 
-    @Column(name = "moment_category")
+    @Column(name = "moment_category", nullable = false)
     private String momentCategory;
 
-    @Column(name = "moment_content")
+    @Column(name = "moment_content", nullable = false)
     private String momentContent;
 
     @Column(name = "moment_certified")
@@ -41,13 +41,16 @@ public class Moment {
     @Column(name = "moment_view")
     private Long momentView;
 
-    @Column(name = "moment_status")
+    @Column(name = "moment_status", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
     private boolean momentStatus;
 
-    @Column(name = "created_at")
+    @Column(name = "moment_image_urls", nullable = false)
+    private String momentImageUrls;
+
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     @Column(name = "location_id")
@@ -55,6 +58,9 @@ public class Moment {
 
     @Column(name = "member_id")
     private Long memberId;
+
+    @Column(name = "couple_id")
+    private Long coupleId;
 
     public void createMoment() {
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/request/RequestCreateMomentVO.java
+++ b/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/request/RequestCreateMomentVO.java
@@ -18,6 +18,7 @@ public class RequestCreateMomentVO {
     private boolean momentCommentStatus;
     private Long momentLike;
     private Long momentView;
+    private String momentImageUrls;
     private Long locationId;
 
     // 처음 추억이 등록되는 경우에는 네이버 지도 API를 통해 정보 반환

--- a/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/request/RequestUpdateMomentVO.java
+++ b/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/request/RequestUpdateMomentVO.java
@@ -14,5 +14,6 @@ public class RequestUpdateMomentVO {
     private String momentTitle;
     private String momentCategory;
     private String momentContent;
+    private String momentImageUrls;
     private boolean momentCommentStatus;
 }

--- a/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/response/ResponseCreateMomentVO.java
+++ b/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/response/ResponseCreateMomentVO.java
@@ -14,5 +14,6 @@ import java.time.LocalDateTime;
 public class ResponseCreateMomentVO {
     private Long momentId;
     private String momentTitle;
+    private String momentImageUrls;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/response/ResponseUpdateMomentVO.java
+++ b/src/main/java/beyond/momentours/moment/command/domain/aggregate/vo/response/ResponseUpdateMomentVO.java
@@ -14,5 +14,6 @@ import java.time.LocalDateTime;
 public class ResponseUpdateMomentVO {
     private Long momentId;
     private String momentTitle;
+    private String momentImageUrls;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/beyond/momentours/moment/common/MomentFilterCondition.java
+++ b/src/main/java/beyond/momentours/moment/common/MomentFilterCondition.java
@@ -3,7 +3,7 @@ package beyond.momentours.moment.common;
 import lombok.*;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
@@ -12,7 +12,8 @@ public class MomentFilterCondition {
     private Long cursor;
     private int size;
     private String sort;
-    private Boolean onlyMine;
+    private Boolean isOurs;
     private Boolean certifiedOnly;
     private Long memberId;
+    private Long coupleId;
 }

--- a/src/main/java/beyond/momentours/moment/common/converter/MomentConverter.java
+++ b/src/main/java/beyond/momentours/moment/common/converter/MomentConverter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MomentConverter {
 
-    public Moment fromDTOToEntity(MomentDTO dto, Long memberId, Long locationId) {
+    public Moment fromDTOToEntity(MomentDTO dto, Long memberId, Long coupleId, Long locationId) {
         return Moment.builder()
                 .momentTitle(dto.getMomentTitle())
                 .momentCategory(dto.getMomentCategory())
@@ -21,10 +21,12 @@ public class MomentConverter {
                 .momentLike(dto.getMomentLike())
                 .momentView(dto.getMomentView())
                 .momentStatus(dto.isMomentStatus())
+                .momentImageUrls(dto.getMomentImageUrls())
                 .createdAt(dto.getCreatedAt())
                 .updatedAt(dto.getUpdatedAt())
                 .locationId(locationId)
                 .memberId(memberId)
+                .coupleId(coupleId)
                 .build();
     }
 
@@ -39,6 +41,7 @@ public class MomentConverter {
                 .momentLike(moment.getMomentLike())
                 .momentView(moment.getMomentView())
                 .momentStatus(moment.isMomentStatus())
+                .momentImageUrls(moment.getMomentImageUrls())
                 .createdAt(moment.getCreatedAt())
                 .updatedAt(moment.getUpdatedAt())
                 .locationId(moment.getLocationId())
@@ -54,6 +57,7 @@ public class MomentConverter {
                 .momentCommentStatus(createMomentVO.isMomentCommentStatus())
                 .momentLike(createMomentVO.getMomentLike())
                 .momentView(createMomentVO.getMomentView())
+                .momentImageUrls(createMomentVO.getMomentImageUrls())
                 .locationId(createMomentVO.getLocationId())
                 .locationName(createMomentVO.getLocationName())
                 .latitude(createMomentVO.getLatitude())
@@ -67,6 +71,7 @@ public class MomentConverter {
                 .momentTitle(vo.getMomentTitle())
                 .momentCategory(vo.getMomentCategory())
                 .momentContent(vo.getMomentContent())
+                .momentImageUrls(vo.getMomentImageUrls())
                 .momentCommentStatus(vo.isMomentCommentStatus())
                 .build();
     }
@@ -76,6 +81,7 @@ public class MomentConverter {
                 .momentId(dto.getMomentId())
                 .momentTitle(dto.getMomentTitle())
                 .createdAt(dto.getCreatedAt())
+                .momentImageUrls(dto.getMomentImageUrls())
                 .build();
     }
 
@@ -84,6 +90,7 @@ public class MomentConverter {
                 .momentId(dto.getMomentId())
                 .momentTitle(dto.getMomentTitle())
                 .updatedAt(dto.getUpdatedAt())
+                .momentImageUrls(dto.getMomentImageUrls())
                 .build();
     }
 }

--- a/src/main/java/beyond/momentours/moment/query/repository/MomentMapper.java
+++ b/src/main/java/beyond/momentours/moment/query/repository/MomentMapper.java
@@ -4,15 +4,25 @@ import beyond.momentours.moment.query.vo.ResponseMomentDetailVO;
 import beyond.momentours.moment.query.vo.ResponseMomentListItemVO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 
 @Mapper
 public interface MomentMapper {
+
     ResponseMomentDetailVO findMomentDetailById(@Param("momentId") Long momentId);
 
-    List<ResponseMomentListItemVO> findMomentsByLocationIdWithFilter(Long locationId, Long cursor, int size, String sort, Boolean onlyMine, Boolean certifiedOnly, Long memberId);
+    List<ResponseMomentListItemVO> findMomentsByLocationIdWithFilter(
+            @Param("locationId") Long locationId,
+            @Param("cursor") Long cursor,
+            @Param("size") int size,
+            @Param("sort") String sort,
+            @Param("isOurs") Boolean isOurs,
+            @Param("certifiedOnly") Boolean certifiedOnly,
+            @Param("memberId") Long memberId,
+            @Param("coupleId") Long coupleId
+    );
 
     boolean existsActiveById(@Param("momentId") Long momentId);
-
 }

--- a/src/main/java/beyond/momentours/moment/query/repository/MomentMapper.java
+++ b/src/main/java/beyond/momentours/moment/query/repository/MomentMapper.java
@@ -4,7 +4,6 @@ import beyond.momentours.moment.query.vo.ResponseMomentDetailVO;
 import beyond.momentours.moment.query.vo.ResponseMomentListItemVO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 

--- a/src/main/java/beyond/momentours/moment/query/vo/ResponseMomentDetailVO.java
+++ b/src/main/java/beyond/momentours/moment/query/vo/ResponseMomentDetailVO.java
@@ -3,12 +3,14 @@ package beyond.momentours.moment.query.vo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class ResponseMomentDetailVO {
     private Long momentId;
     private String momentTitle;
@@ -18,8 +20,12 @@ public class ResponseMomentDetailVO {
     private Boolean momentCommentStatus;
     private Long momentLike;
     private Long momentView;
+    private Long commentCount;
     private String locationName;
     private String address;
+    private String momentImageUrl;
     private String memberNickname;
+    private String coupleName;
+    private String couplePhoto;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/beyond/momentours/moment/query/vo/ResponseMomentListItemVO.java
+++ b/src/main/java/beyond/momentours/moment/query/vo/ResponseMomentListItemVO.java
@@ -3,13 +3,24 @@ package beyond.momentours.moment.query.vo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class ResponseMomentListItemVO {
     private Long momentId;
     private String momentTitle;
     private String momentCategory;
     private String locationName;
+    private String momentImageUrl;
+    private String momentContent;
+    private boolean isOurs;
+    private boolean commentEnabled;
+    private Long likeCount;
+    private Long viewCount;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/beyond/momentours/report/command/domain/aggregate/ReportReason.java
+++ b/src/main/java/beyond/momentours/report/command/domain/aggregate/ReportReason.java
@@ -8,7 +8,10 @@ public enum ReportReason {
     OBSCENITY("Obscenity"),                     // 음란
     FALSE_INFORMATION("False Information"),     // 잘못된 정보
     POLITICAL_STATEMENT("Political Statement"), // 정치적 발언
-    ADVERTISING("Advertising");                 // 광고성 내용
+    ADVERTISING("Advertising"),                 // 광고성 내용
+    CLOSED("Closed"),                           // 폐업
+    RELOCATION("Relocation"),                   // 이전
+    WRONG_INFO("Wrong Info");                   // 잘못된 정보
 
     private final String reason;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
       hibernate:
         format_sql: true
     generate-ddl: false
+    open-in-view: false
 
   data:
     redis:
@@ -37,6 +38,17 @@ spring:
           connectiontimeout: 20000
           timeout: 20000
           writetimeout: 20000
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: like-consumer
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 logging:
   level:

--- a/src/main/resources/beyond/momentours/mapper/location/LocationMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/location/LocationMapper.xml
@@ -10,9 +10,47 @@
         <result property="longitude" column="longitude"/>
         <result property="locationName" column="location_name"/>
         <result property="address" column="address"/>
+        <result property="imageUrl" column="image_url"/>
         <result property="locationStatus" column="location_status"/>
+        <result property="description" column="description"/>
+        <result property="rating" column="rating"/>
+        <result property="isOpen" column="is_open"/>
+        <result property="closingTime" column="closing_time"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <resultMap id="ResponseLocationMapVOMap" type="beyond.momentours.location.query.vo.ResponseLocationMapVO">
+        <result property="locationId" column="locationId"/>
+        <result property="locationName" column="locationName"/>
+        <result property="latitude" column="latitude"/>
+        <result property="longitude" column="longitude"/>
+        <result property="momentCount" column="momentCount"/>
+        <result property="description" column="description"/>
+        <result property="images" column="images"/>
+    </resultMap>
+
+    <resultMap id="ClusterItemVOMap" type="beyond.momentours.location.query.vo.ResponseLocationClusterItemVO">
+        <result property="locationIds" column="locationIds"/>
+        <result property="locationId" column="locationId"/>
+        <result property="locationName" column="locationName"/>
+        <result property="latitude" column="latitude"/>
+        <result property="longitude" column="longitude"/>
+        <result property="count" column="count"/>
+        <result property="momentCount" column="momentCount"/>
+    </resultMap>
+
+    <resultMap id="LocationDetailVOMap" type="beyond.momentours.location.query.vo.ResponseLocationDetailVO">
+        <result property="locationId" column="locationId"/>
+        <result property="locationName" column="locationName"/>
+        <result property="address" column="address"/>
+        <result property="images" column="images"/>
+        <result property="description" column="description"/>
+        <result property="latitude" column="latitude"/>
+        <result property="longitude" column="longitude"/>
+        <result property="momentCount" column="momentCount"/>
+        <result property="totalView" column="totalView"/>
+        <result property="totalLike" column="totalLike"/>
     </resultMap>
 
     <select id="findByLatitudeAndLongitudeAndLocationName" resultMap="locationResultMap">
@@ -47,22 +85,86 @@
         AND location_status = 'UNCHANGED'
     </select>
 
-    <select id="findLocationsInBounds" resultType="beyond.momentours.location.query.vo.ResponseLocationMapVO">
-        SELECT l.location_id AS locationId, l.location_name AS locationName, l.latitude, l.longitude, COUNT(m.moment_id) AS momentCount
+    <select id="findLocationsInBounds" resultMap="ResponseLocationMapVOMap">
+        SELECT l.location_id AS locationId, 
+               l.location_name AS locationName, 
+               l.latitude, 
+               l.longitude, 
+               COUNT(m.moment_id) AS momentCount, 
+               l.description,
+               l.image_urls AS images
           FROM tb_location l
           LEFT JOIN tb_moment m ON l.location_id = m.location_id AND m.moment_status = true
          WHERE l.latitude BETWEEN #{latitudeMin} AND #{latitudeMax}
            AND l.longitude BETWEEN #{longitudeMin} AND #{longitudeMax}
+           AND l.location_status = 'UNCHANGED'
          GROUP BY l.location_id
     </select>
 
-    <select id="findLocationsNearCoordinates" resultType="beyond.momentours.location.query.vo.ResponseLocationClusterItemVO">
-        SELECT l.location_id AS locationId, l.location_name AS locationName, l.latitude, l.longitude, COUNT(m.moment_id) AS momentCount
+    <select id="findClusteredLocationsByZoomLevel" resultMap="ClusterItemVOMap">
+        SELECT * FROM (
+          SELECT GROUP_CONCAT(location_id) AS locationIds, NULL AS locationId, NULL AS locationName,
+                latitude, longitude, COUNT(*) AS count, NULL AS momentCount
+          FROM tb_location
+          WHERE location_status = 'UNCHANGED'
+            AND latitude BETWEEN #{latitudeMin} AND #{latitudeMax}
+            AND longitude BETWEEN #{longitudeMin} AND #{longitudeMax}
+          GROUP BY latitude, longitude
+          HAVING COUNT(*) > 1
+
+          UNION
+
+          SELECT CAST(location_id AS CHAR) AS locationIds, location_id AS locationId, location_name AS locationName,
+                latitude, longitude, 1 AS count,
+                (SELECT COUNT(*) FROM tb_moment m WHERE m.location_id = l.location_id AND m.moment_status = true) AS momentCount
           FROM tb_location l
-          LEFT JOIN tb_moment m ON l.location_id = m.location_id AND m.moment_status = true
-         WHERE ROUND(l.latitude, 2) = ROUND(#{lat}, 2)
-           AND ROUND(l.longitude, 2) = ROUND(#{lng}, 2)
-         GROUP BY l.location_id
+          WHERE location_status = 'UNCHANGED'
+            AND latitude BETWEEN #{latitudeMin} AND #{latitudeMax}
+            AND longitude BETWEEN #{longitudeMin} AND #{longitudeMax}
+          GROUP BY latitude, longitude, location_id
+          HAVING COUNT(*) = 1
+        ) AS clustered
+    </select>
+
+    <select id="findClusteredLocationsByZoomLevelWithLimit" resultMap="ClusterItemVOMap">
+        SELECT * FROM (
+          SELECT GROUP_CONCAT(location_id) AS locationIds, NULL AS locationId, NULL AS locationName,
+                latitude, longitude, COUNT(*) AS count, NULL AS momentCount
+          FROM tb_location
+          WHERE location_status = 'UNCHANGED'
+            AND latitude BETWEEN #{latitudeMin} AND #{latitudeMax}
+            AND longitude BETWEEN #{longitudeMin} AND #{longitudeMax}
+          GROUP BY latitude, longitude
+          HAVING COUNT(*) > 1
+
+          UNION
+
+          SELECT CAST(location_id AS CHAR) AS locationIds, location_id AS locationId, location_name AS locationName,
+                latitude, longitude, 1 AS count,
+                (SELECT COUNT(*) FROM tb_moment m WHERE m.location_id = l.location_id AND m.moment_status = true) AS momentCount
+          FROM tb_location l
+          WHERE location_status = 'UNCHANGED'
+            AND latitude BETWEEN #{latitudeMin} AND #{latitudeMax}
+            AND longitude BETWEEN #{longitudeMin} AND #{longitudeMax}
+          GROUP BY latitude, longitude, location_id
+          HAVING COUNT(*) = 1
+        ) AS clustered
+        LIMIT #{limit}
+    </select>
+
+    <select id="findLocationsByRoundedCoordinate" resultType="beyond.momentours.location.query.vo.ResponseLocationMapVO">
+        SELECT l.location_id AS locationId,
+        l.location_name AS locationName,
+        l.latitude,
+        l.longitude,
+        COUNT(m.moment_id) AS momentCount
+        FROM tb_location l
+        LEFT JOIN tb_moment m
+        ON l.location_id = m.location_id AND m.moment_status = true
+        WHERE l.location_status = 'UNCHANGED'
+        AND ROUND(l.latitude, #{round}) = ROUND(#{latitude}, #{round})
+        AND ROUND(l.longitude, #{round}) = ROUND(#{longitude}, #{round})
+        GROUP BY l.location_id
     </select>
 
     <select id="findGroupedLocationClusters" resultType="beyond.momentours.location.query.vo.ResponseLocationClusterGroupVO">
@@ -114,14 +216,16 @@
     </select>
 
     <select id="findRecommendedNearbyLocations" resultType="beyond.momentours.location.query.vo.ResponseLocationMapVO">
-        SELECT l.location_id AS locationId, l.location_name AS locationName, l.latitude, l.longitude,
+        SELECT l.location_id AS locationId, 
+               l.location_name AS locationName, 
+               l.latitude, 
+               l.longitude,
                (
                COALESCE(SUM(m.moment_view), 0) +
-               COALESCE(COUNT(ml.like_id), 0) * 5
+               COALESCE(SUM(m.moment_like), 0) * 5
                ) AS score
           FROM tb_location l
           LEFT JOIN tb_moment m ON m.location_id = l.location_id AND m.moment_status = true
-          LEFT JOIN tb_moment_like ml ON ml.moment_id = m.moment_id
          WHERE ST_Distance_Sphere(l.location_point, ST_GeomFromText(CONCAT('POINT(', #{longitude}, ' ', #{latitude}, ')'))) &lt;= #{radiusMeters}
            AND l.location_status = 'UNCHANGED'
          GROUP BY l.location_id
@@ -129,18 +233,21 @@
          LIMIT #{limit}
     </select>
 
-    <select id="getLocationDetail" resultType="beyond.momentours.location.query.vo.ResponseLocationDetailVO">
-        SELECT l.location_id AS locationId, l.location_name AS locationName, l.address, l.latitude, l.longitude, COUNT(m.moment_id) AS momentCount, COALESCE(SUM(m.moment_view), 0) AS totalView,
-               COALESCE(SUM(
-                        (SELECT COUNT(*)
-                           FROM tb_moment_like ml
-                          WHERE ml.moment_id = m.moment_id)
-                        ), 0) AS totalLike
+    <select id="getLocationDetail" resultMap="LocationDetailVOMap">
+        SELECT l.location_id AS locationId, 
+               l.location_name AS locationName, 
+               l.address, 
+               l.image_urls AS images,
+               l.description, 
+               l.latitude, 
+               l.longitude, 
+               COUNT(m.moment_id) AS momentCount, 
+               COALESCE(SUM(m.moment_view), 0) AS totalView,
+               COALESCE(SUM(m.moment_like), 0) AS totalLike
           FROM tb_location l
           LEFT JOIN tb_moment m ON l.location_id = m.location_id AND m.moment_status = true
          WHERE l.location_id = #{locationId}
          GROUP BY l.location_id
     </select>
-
 
 </mapper>

--- a/src/main/resources/beyond/momentours/mapper/moment/MomentMapper.xml
+++ b/src/main/resources/beyond/momentours/mapper/moment/MomentMapper.xml
@@ -5,17 +5,57 @@
 
 <mapper namespace="beyond.momentours.moment.query.repository.MomentMapper">
 
-    <select id="findMomentsByLocationIdWithFilter" resultType="beyond.momentours.moment.query.vo.ResponseMomentListItemVO">
-        SELECT m.moment_id AS momentId, m.moment_title AS momentTitle, m.moment_category AS momentCategory, l.location_name AS locationName
-          FROM tb_moment m
+    <resultMap id="momentListItemMap" type="beyond.momentours.moment.query.vo.ResponseMomentListItemVO">
+        <result property="momentId" column="momentId"/>
+        <result property="momentTitle" column="momentTitle"/>
+        <result property="momentCategory" column="momentCategory"/>
+        <result property="locationName" column="locationName"/>
+        <result property="momentImageUrl" column="momentImageUrl"/>
+        <result property="momentContent" column="momentContent"/>
+        <result property="isOurs" column="isOurs"/>
+        <result property="commentEnabled" column="commentEnabled"/>
+        <result property="likeCount" column="likeCount"/>
+        <result property="viewCount" column="viewCount"/>
+        <result property="createdAt" column="createdAt"/>
+    </resultMap>
+
+    <resultMap id="momentDetailMap" type="beyond.momentours.moment.query.vo.ResponseMomentDetailVO">
+        <result property="momentId" column="momentId"/>
+        <result property="momentTitle" column="momentTitle"/>
+        <result property="momentCategory" column="momentCategory"/>
+        <result property="momentContent" column="momentContent"/>
+        <result property="momentCertified" column="momentCertified"/>
+        <result property="momentCommentStatus" column="momentCommentStatus"/>
+        <result property="momentLike" column="momentLike"/>
+        <result property="momentView" column="momentView"/>
+        <result property="locationName" column="locationName"/>
+        <result property="address" column="address"/>
+        <result property="momentImageUrl" column="momentImageUrl"/>
+        <result property="coupleName" column="coupleName"/>
+        <result property="couplePhoto" column="couplePhoto"/>
+        <result property="createdAt" column="createdAt"/>
+    </resultMap>
+
+    <select id="findMomentsByLocationIdWithFilter" resultMap="momentListItemMap">
+        SELECT m.moment_id AS momentId, m.moment_title AS momentTitle, m.moment_category AS momentCategory, l.location_name AS locationName,
+               SUBSTRING_INDEX(m.moment_image_urls, ',', 1) AS momentImageUrl, m.moment_content AS momentContent, m.moment_comment_status AS commentEnabled, m.moment_like AS likeCount,
+               m.moment_view AS viewCount, m.created_at AS createdAt, CASE WHEN m.couple_id = #{coupleId} THEN true ELSE false END AS isOurs
+        FROM tb_moment m
           JOIN tb_location l ON m.location_id = l.location_id
          WHERE m.moment_status = true
            AND m.location_id = #{locationId}
         <if test="cursor != null">
             AND m.moment_id &lt; #{cursor}
         </if>
-        <if test="onlyMine != null and onlyMine == true">
-            AND m.member_id = #{memberId}
+        <if test="isOurs != null">
+            <choose>
+                <when test="isOurs == true">
+                    AND m.couple_id = #{coupleId}
+                </when>
+                <otherwise>
+                    AND (m.couple_id IS NULL OR m.couple_id != #{coupleId})
+                </otherwise>
+            </choose>
         </if>
         <if test="certifiedOnly != null and certifiedOnly == true">
             AND m.moment_certified = true
@@ -28,16 +68,18 @@
                 ORDER BY m.moment_id DESC
             </otherwise>
         </choose>
-           LIMIT #{size}
+         LIMIT #{size}
     </select>
 
-    <select id="findMomentDetailById" resultType="beyond.momentours.moment.query.vo.ResponseMomentDetailVO">
-        SELECT m.moment_id AS momentId, m.moment_title AS momentTitle, m.moment_category AS momentCategory, m.moment_content AS momentContent, m.moment_certified AS momentCertified, m.moment_comment_status AS momentCommentStatus, m.moment_like AS momentLike, m.moment_view AS momentView, l.location_name AS locationName, l.address AS address, mem.member_nickname AS memberNickname, m.created_at AS createdAt
+    <select id="findMomentDetailById" resultMap="momentDetailMap">
+        SELECT m.moment_id AS momentId, m.moment_title AS momentTitle, m.moment_category AS momentCategory, m.moment_content AS momentContent, m.moment_certified AS momentCertified, m.moment_comment_status AS momentCommentStatus, m.moment_like AS momentLike, m.moment_view AS momentView,
+               l.location_name AS locationName, l.address AS address, SUBSTRING_INDEX(m.moment_image_urls, ',', 1) AS momentImageUrl, mem.member_nickname AS memberNickname, c.couple_name AS coupleName, c.couple_photo AS couplePhoto, m.created_at AS createdAt
           FROM tb_moment m
           JOIN tb_location l ON m.location_id = l.location_id
-          JOIN tb_member mem ON m.member_id = mem.member_id
-         WHERE m.moment_id = #{momentId}
-           AND m.moment_status = true
+        JOIN tb_member mem ON m.member_id = mem.member_id
+        LEFT JOIN tb_couple_list c ON m.couple_id = c.couple_id AND c.couple_status = 1
+        WHERE m.moment_id = #{momentId}
+        AND m.moment_status = true
     </select>
 
     <select id="existsActiveById" resultType="boolean">


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
좋아요 기능 (redis, redisson, kafka 활용) 고도화, 장소 검색 시 클러스터링 조회 및 상세 조회, 추억 관련 api 메서드 수정했습니다.

1. 좋아요에 따라 사용자에게는 새로고침할 때마다 ('redis 캐시 안에 있는 좋아요 개수' + DB에 있는 '해당 엔터티의 좋아요 개수' 컬럼 데이터) 로 보여주기
2. 스케줄러로 특정 시간마다 레디스에 있는 데이터 DB에 update
3. Redis에 저장된 좋아요 수는 일정 주기마다 스케줄러가 실행돼서 DB로 동기화됨.
4. 사용자가 좋아요를 누르거나 취소할 때, 비정규화 된 Like DB에 저장/삭제하고 동시에 Redis 값을 증가/감소시킴
5. 동시에 여러 서버에서 같은 사용자가 같은 대상에 좋아요를 누를 경우를 대비해서 Redisson 분산 락을 걸어서 중복 처리를 막음.
6. 좋아요 누르기 전에 해당 대상(Moment, DateCourse)이 삭제된 상태인지 확인해서, 이미 삭제된 대상에는 좋아요를 못 누르게 막음.
7. Redis에서 동기화 도중 실패한 키가 있다면, 동기화에 실패한 키를 별도 retry key로 남기고, 재시도 스케줄러가 따로 처리함.
8. Redis가 장애 발생 시 kafka 로 회복하는 동안 사용

Location, Moment 쪽 api 추가 및 수정해뒀습니다.
